### PR TITLE
SPEC: Basis datatype representations for protocols in node implementer specs

### DIFF
--- a/SWIPs/swip-16-data-types-descriptions.md
+++ b/SWIPs/swip-16-data-types-descriptions.md
@@ -1,7 +1,7 @@
 ---
 SWIP: 16
 title: Swarm node implementer spec - 
-author: Louis Holbrook @nolash <dev@holbrook.no>
+author: Louis Holbrook <dev@holbrook.no> (https://holbrook.no)
 status: Draft
 type: Track Specs
 created: 2019-08-02
@@ -36,24 +36,32 @@ Copyright and related rights waived via CC0
 ### Data representations
 
 This document uses the `ABNF` convention for defining data types, as
-described in the IETF RFC 5234. 
+described in the IETF RFC 5234. [1]
 
 #### Primitives
 
-The basic identifiers are defined as follows:
+The basic identifiers are defined as follows[2]
 
-| id  | def |
-| --- | :--- |
-|    UINT64MAX  | 18446744073709551615 |
-|    UINT32MAX  | 4294967295 |
-|    UINT16MAX  | 65535 |
-|    UINT8MAX   | 255 |
-|    UINT64     | %d0-UINT64MAX |
-|    UINT32     | %d0-UINT32MAX |
-|    UINT16     | %d0-UINT16MAX |
-|    UINT8      | %d0-UINT8MAX |
-|    BOOL       | BIT |
-|    TIMESTAMP  | UINT32 |
+| id | def |
+| :--- | :---- |
+| UINT64MAX | 18446744073709551615 |
+| UINT32MAX | 4294967295 |
+| UINT16MAX | 65535 |
+| UINT8MAX | 255 |
+| UINT64 | %d0-UINT64MAX |
+| UINT32 | %d0-UINT32MAX |
+| UINT16 | %d0-UINT16MAX |
+| UINT8 | %d0-UINT8MAX |
+
+| id | def |
+| :--- | :---- |
+| BOOL | BIT |
+
+| id | def |
+| :--- | :---- |
+| TIMESTAMP | UINT32 |
+
+#### Network specific types
 
 #### Rule extension for list definitions
 
@@ -61,10 +69,15 @@ The construct `LIST` explicitly defines a list of elements. Elements may
 be of any serializable type, and are separated by spaces:
 
 | id | def |
-|--|:--|
-|    LIST   | *(*OCTET / TIMESTAMP / UINT8 / UINT16 / UINT32 / UINT64 ) |
+| :--- | :---- |
+| LIST | *(*OCTET / TIMESTAMP / UINT8 / UINT16 / UINT32 / UINT64 ) |
 
 This identifier has implications for the serialization of data. Please
 refer to the serialization appendices for details and examples of
 serializations of the data types throughout this document:
-[\[rlp\]](#rlp)
+[[rlp]](#rlp)
+
+1.  Network Working Group Augmented BNF for Syntax Specifications: ABN,
+    IETF, https://tools.ietf.org/rfc/rfc5234.txt, Retrieved 01.08.2019,
+
+2.  Numeric values are (2^n-1)

--- a/SWIPs/swip-16-data-types-descriptions.md
+++ b/SWIPs/swip-16-data-types-descriptions.md
@@ -1,5 +1,5 @@
 ---
-SWIP: <To be assigned>
+SWIP: 16
 title: Swarm node implementer spec - 
 author: Louis Holbrook @nolash <dev@holbrook.no>
 status: Draft

--- a/SWIPs/swip-data-types-descriptions.md
+++ b/SWIPs/swip-data-types-descriptions.md
@@ -7,13 +7,13 @@ type: General
 created: 2019-08-02
 ---
 
-## abstract
+## Abstract
 
-This SWIP defines pseudo data types for use in Swarm protocol specifications.
+This SWIP defines pseudo data types for use in Swarm protocol specifications, and their serialization to RLP.
 
-## motivation
+## Motivation
 
-To describe protocols in our specifications, we are in need of a strongly defined way of describing data types and their serializations to RLP.
+To describe protocols in our specifications, we are in need of a strongly defined way of describing data types and their serializations to RLP. RLP is the relevant format in this case, as it is the serialization format currently being used in devp2p, and Swarm is currently based on devp2p.
 
 RLP does not have "types" as such, just self-describing data units whose length is serially interpreted. Hence it is for example not possible to define a number value range merely in terms of RLP constructs.
 
@@ -64,7 +64,7 @@ All other data is encoded as RLP lists.
 
 The outermost element of a serialization is always a LIST item [^1]
 
-## example
+### example
 
 A message structure with only one field of `3OCTET` data will in
 *reality* be `LIST(3OCTET)`. If the data is `0x666f6f` it will serialize
@@ -75,3 +75,19 @@ LIST:   0xc4 (list, 4 bytes long)
 3OCTET: 0x83 (string, 3 bytes long)
 data:   0x66 0x6f 0x6f
 ```
+
+## Backwards Compatibility
+
+There are no compatibility issues.
+
+## Test Cases
+
+There are no relevant test cases.
+
+## Implementation
+
+Any future SWIP defining Swarm protocols.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/SWIPs/swip-data-types-descriptions.md
+++ b/SWIPs/swip-data-types-descriptions.md
@@ -52,26 +52,13 @@ implications for the RLP encoding of the data, as described in [3].
 We define the following mappings from ABNF data type definitions to RLP
 data types:
 
-BOOL
-
-:   is encoded as an RLP encoded integer with length of one byte
-
-OCTET
-
-:   is encoded as an RLP encoded integer with length of one byte
-
-TIMESTAMP
-
-:   is encoded as an RLP encoded variable length integer
-
-\%x\#\#
-
-:   hexadecimal literals are encoded as encoded integers with length of
-    one byte, corresponding to its hexadecimal (not its string) value
-
-LIST
-
-:   as defined in [1.1.3] will be RLP encoded as RLP lists.
+|---|---|
+|BOOL|is encoded as an RLP encoded integer with length of one byte|
+|OCTET|is encoded as an RLP encoded integer with length of one byte|
+|TIMESTAMP|is encoded as an RLP encoded variable length integer|
+|\%x\#\#|hexadecimal literals are encoded as encoded integers with length of one byte, corresponding to its hexadecimal (not its string) value|
+|LIST|as defined in [1.1.3] will be RLP encoded as RLP lists|
+|---|---|
 
 All other data is encoded as RLP lists.
 

--- a/SWIPs/swip-data-types-descriptions.md
+++ b/SWIPs/swip-data-types-descriptions.md
@@ -4,7 +4,7 @@ title: Swarm node implementer spec -
 author: Louis Holbrook @nolash <dev@holbrook.no>
 status: Draft
 type: Track Specs
-created: 2019-
+created: 2019-08-02
 ---
 
 ## Abstract
@@ -31,14 +31,14 @@ N/A
 
 Copyright and related rights waived via CC0
 
-# introduction
+## Specification
 
-## data representations
+### data representations
 
 This document uses the `ABNF` convention for defining data types, as
 described in the IETF RFC 5234. 
 
-### primitives
+#### primitives
 
 The basic identifiers are defined as follows:
 
@@ -55,98 +55,12 @@ The basic identifiers are defined as follows:
     
     TIMESTAMP   = UINT32
 
-### network specific types
+#### network specific types
 
-### rule extension for list definitions
+#### rule extension for list definitions
 
 The construct `LIST` explicitly defines a list of elements. Elements may
 be of any type, and are separated by spaces. This identifier has
-implications for the RLP encoding of the data, as described in
-[3](#protocols).
-
-# fundamentals
-
-## Swarm Overlay Address
-
-Swarm addresses all content and all nodes with 32-byte hashes. A node
-address is called its Swarm Overlay Address. It is derived from the
-public key of the Ethereum account used to operate the node.
-
-To obtain the Swarm Overlay Address, hash the *uncompressed* form of the
-public key, *including* its \(04\) (uncompressed) prefix, using the
-KECCAK256 hashing algorithm.   
-
-Formally we define the Swarm Overlay Address thus:
-
-    OVERLAYADDRESS = 32*(%x00-ff)
-
-## Swarm Address Pair
-
-To enable peers to locate the a node on the network, the aforementioned
-Swarm Overlay Address is paired with an Underlay Address. The Underlay
-Address is a string representation of the node’s network location on the
-underlying transport layer.
-
-Currently the url string representation of the devp2p V4 Enode ID is
-used for this value. Although this value currently serves no practical
-purpose within the operations of the Swarm node, the handshake *MUST*
-fail if the string cannot be parsed as a valid Enode ID. 
-
-We here add the following definitions:
-
-    ENODEPREFIX = "enode://"
-    PUBLICKEYHEX = "04" 64HEXDIG
-    HOST = IP / FQDN
-    UNDERLAYADDRESS = ENODEPREFIX PUBLICKEYHEX "@" HOST ":" PORT
-    ADDRESSPAIR=2#2list(OVERLAYADDRESS UNDERLAYADDRESS)
-
-# protocols
-
-Swarm protocols require a p2p transport protocol.
-
-At the time of writing, the Swarm reference implementation depends on
-the devp2p protocol, including its RLPX wire format and encryption
-scheme.  Detailing the concepts of `devp2p` and `RLP(X)` as such is out
-of scope of this document.
-
-Data payloads will be defined in ABNF format. Reference examples to
-verify the correct `RLP` encoded form of the data will also be included.
-
-We define the following mappings from ABNF data type definitions to RLP
-data types:
-
-  - BOOL  
-    is encoded as an RLP encoded integer with length of one byte
-
-  - OCTET  
-    is encoded as an RLP encoded integer with length of one byte
-
-  - TIMESTAMP  
-    is encoded as an RLP encoded variable length integer
-
-  - %x\#\#  
-    hexadecimal literals are encoded as encoded integers with length of
-    one byte, corresponding to its hexadecimal (not its string) value
-
-  - LIST  
-    as defined in [1.1.3](#abnf-list-definition) will be RLP encoded as
-    RLP lists.
-
-All other data is encoded as RLP lists.
-
-The outermost element of a serialization is always a LIST item [1]
-
-## example
-
-A message structure with only one field of `3OCTET` data will in
-*reality* be `LIST(3OCTET)`. If the data is `0x666f6f` it will serialize
-to `0xc4 83 66 6f 6f`, which breaks down to:
-
-    LIST:   0xc4 (list, 4 bytes long)
-    3OCTET: 0x83 (string, 3 bytes long)
-    data:   0x66 0x6f 0x6f
-
-
-1.  This is due to the fact that the reference implementation is written
-    in golang, and the default RLP deserialization of golang structs
-    treats the struct itself as a list.
+implications for the serialization of data. Please refer to the
+serialization appendices for details and examples of serializations of
+the data types throughout this document: [\[rlp\]](#rlp)

--- a/SWIPs/swip-data-types-descriptions.md
+++ b/SWIPs/swip-data-types-descriptions.md
@@ -1,5 +1,5 @@
 ---
-SWIP: <to be assigned>
+SWIP: <To be assigned>
 title: Swarm node implementer spec - 
 author: Louis Holbrook @nolash <dev@holbrook.no>
 status: Draft
@@ -33,34 +33,38 @@ Copyright and related rights waived via CC0
 
 ## Specification
 
-### data representations
+### Data representations
 
 This document uses the `ABNF` convention for defining data types, as
 described in the IETF RFC 5234. 
 
-#### primitives
+#### Primitives
 
 The basic identifiers are defined as follows:
 
-    UINT64MAX   = 18446744073709551615
-    UINT32MAX   = 4294967295
-    UINT16MAX   = 65535
-    UINT8MAX    = 255
-    UINT64      = %d0-UINT64MAX
-    UINT32      = %d0-UINT32MAX
-    UINT16      = %d0-UINT16MAX
-    UINT8       = %d0-UINT8MAX
-    
-    BOOL        = BIT
-    
-    TIMESTAMP   = UINT32
+| id  | def |
+| --- | :--- |
+|    UINT64MAX  | 18446744073709551615 |
+|    UINT32MAX  | 4294967295 |
+|    UINT16MAX  | 65535 |
+|    UINT8MAX   | 255 |
+|    UINT64     | %d0-UINT64MAX |
+|    UINT32     | %d0-UINT32MAX |
+|    UINT16     | %d0-UINT16MAX |
+|    UINT8      | %d0-UINT8MAX |
+|    BOOL       | BIT |
+|    TIMESTAMP  | UINT32 |
 
-#### network specific types
-
-#### rule extension for list definitions
+#### Rule extension for list definitions
 
 The construct `LIST` explicitly defines a list of elements. Elements may
-be of any type, and are separated by spaces. This identifier has
-implications for the serialization of data. Please refer to the
-serialization appendices for details and examples of serializations of
-the data types throughout this document: [\[rlp\]](#rlp)
+be of any serializable type, and are separated by spaces:
+
+| id | def |
+|--|:--|
+|    LIST   | *(*OCTET / TIMESTAMP / UINT8 / UINT16 / UINT32 / UINT64 ) |
+
+This identifier has implications for the serialization of data. Please
+refer to the serialization appendices for details and examples of
+serializations of the data types throughout this document:
+[\[rlp\]](#rlp)

--- a/SWIPs/swip-data-types-descriptions.md
+++ b/SWIPs/swip-data-types-descriptions.md
@@ -52,13 +52,13 @@ implications for the RLP encoding of the data, as described in [3].
 We define the following mappings from ABNF data type definitions to RLP
 data types:
 
-|---|---|
+|type|description|
+|:---|:---|
 |BOOL|is encoded as an RLP encoded integer with length of one byte|
 |OCTET|is encoded as an RLP encoded integer with length of one byte|
 |TIMESTAMP|is encoded as an RLP encoded variable length integer|
 |\%x\#\#|hexadecimal literals are encoded as encoded integers with length of one byte, corresponding to its hexadecimal (not its string) value|
 |LIST|as defined in [1.1.3] will be RLP encoded as RLP lists|
-|---|---|
 
 All other data is encoded as RLP lists.
 

--- a/SWIPs/swip-data-types-descriptions.md
+++ b/SWIPs/swip-data-types-descriptions.md
@@ -1,0 +1,90 @@
+---
+SWIP: <to be assigned>
+title: Type definitions for protocol messages
+author: Louis Holbrook @nolash <dev@holbrook.no>
+status: Draft
+type: General
+created: 2019-08-02
+---
+
+## abstract
+
+This SWIP defines pseudo data types for use in Swarm protocol specifications.
+
+## motivation
+
+To describe protocols in our specifications, we are in need of a strongly defined way of describing data types and their serializations to RLP.
+
+RLP does not have "types" as such, just self-describing data units whose length is serially interpreted. Hence it is for example not possible to define a number value range merely in terms of RLP constructs.
+
+## Specification
+
+This document uses the `ABNF` convention for defining data types, as
+described in the IETF RFC 5234. [@IETF:ABNF]
+
+### primitives
+
+The basic identifiers are defined as follows:
+
+``` {numbers="none"}
+UINT64MAX   = 18446744073709551615
+UINT32MAX   = 4294967295
+UINT16MAX   = 65535
+UINT8MAX    = 255
+UINT64      = %d0-UINT64MAX
+UINT32      = %d0-UINT32MAX
+UINT16      = %d0-UINT16MAX
+UINT8       = %d0-UINT8MAX
+
+BOOL        = BIT
+
+TIMESTAMP   = UINT32
+```
+
+### rule extension for list definitions {#abnf-list-definition}
+
+The construct `LIST` explicitly defines a list of elements. Elements may
+be of any type, and are separated by spaces. This identifier has
+implications for the RLP encoding of the data, as described in [3].
+
+### general types
+
+We define the following mappings from ABNF data type definitions to RLP
+data types:
+
+BOOL
+
+:   is encoded as an RLP encoded integer with length of one byte
+
+OCTET
+
+:   is encoded as an RLP encoded integer with length of one byte
+
+TIMESTAMP
+
+:   is encoded as an RLP encoded variable length integer
+
+\%x\#\#
+
+:   hexadecimal literals are encoded as encoded integers with length of
+    one byte, corresponding to its hexadecimal (not its string) value
+
+LIST
+
+:   as defined in [1.1.3] will be RLP encoded as RLP lists.
+
+All other data is encoded as RLP lists.
+
+The outermost element of a serialization is always a LIST item [^1]
+
+## example
+
+A message structure with only one field of `3OCTET` data will in
+*reality* be `LIST(3OCTET)`. If the data is `0x666f6f` it will serialize
+to `0xc4 83 66 6f 6f`, which breaks down to:
+
+```
+LIST:   0xc4 (list, 4 bytes long)
+3OCTET: 0x83 (string, 3 bytes long)
+data:   0x66 0x6f 0x6f
+```

--- a/SWIPs/swip-data-types-descriptions.md
+++ b/SWIPs/swip-data-types-descriptions.md
@@ -1,93 +1,118 @@
----
-SWIP: <to be assigned>
-title: Type definitions for protocol messages
-author: Louis Holbrook @nolash <dev@holbrook.no>
-status: Draft
-type: General
-created: 2019-08-02
----
+# introduction
 
-## Abstract
-
-This SWIP defines pseudo data types for use in Swarm protocol specifications, and their serialization to RLP.
-
-## Motivation
-
-To describe protocols in our specifications, we are in need of a strongly defined way of describing data types and their serializations to RLP. RLP is the relevant format in this case, as it is the serialization format currently being used in devp2p, and Swarm is currently based on devp2p.
-
-RLP does not have "types" as such, just self-describing data units whose length is serially interpreted. Hence it is for example not possible to define a number value range merely in terms of RLP constructs.
-
-## Specification
+## data representations
 
 This document uses the `ABNF` convention for defining data types, as
-described in the IETF RFC 5234. [@IETF:ABNF]
+described in the IETF RFC 5234. 
 
 ### primitives
 
 The basic identifiers are defined as follows:
 
-``` {numbers="none"}
-UINT64MAX   = 18446744073709551615
-UINT32MAX   = 4294967295
-UINT16MAX   = 65535
-UINT8MAX    = 255
-UINT64      = %d0-UINT64MAX
-UINT32      = %d0-UINT32MAX
-UINT16      = %d0-UINT16MAX
-UINT8       = %d0-UINT8MAX
+    UINT64MAX   = 18446744073709551615
+    UINT32MAX   = 4294967295
+    UINT16MAX   = 65535
+    UINT8MAX    = 255
+    UINT64      = %d0-UINT64MAX
+    UINT32      = %d0-UINT32MAX
+    UINT16      = %d0-UINT16MAX
+    UINT8       = %d0-UINT8MAX
+    
+    BOOL        = BIT
+    
+    TIMESTAMP   = UINT32
 
-BOOL        = BIT
+### network specific types
 
-TIMESTAMP   = UINT32
-```
-
-### rule extension for list definitions {#abnf-list-definition}
+### rule extension for list definitions
 
 The construct `LIST` explicitly defines a list of elements. Elements may
 be of any type, and are separated by spaces. This identifier has
-implications for the RLP encoding of the data, as described in [3].
+implications for the RLP encoding of the data, as described in
+[3](#protocols).
 
-### general types
+# fundamentals
+
+## Swarm Overlay Address
+
+Swarm addresses all content and all nodes with 32-byte hashes. A node
+address is called its Swarm Overlay Address. It is derived from the
+public key of the Ethereum account used to operate the node.
+
+To obtain the Swarm Overlay Address, hash the *uncompressed* form of the
+public key, *including* its \(04\) (uncompressed) prefix, using the
+KECCAK256 hashing algorithm.   
+
+Formally we define the Swarm Overlay Address thus:
+
+    OVERLAYADDRESS = 32*(%x00-ff)
+
+## Swarm Address Pair
+
+To enable peers to locate the a node on the network, the aforementioned
+Swarm Overlay Address is paired with an Underlay Address. The Underlay
+Address is a string representation of the node’s network location on the
+underlying transport layer.
+
+Currently the url string representation of the devp2p V4 Enode ID is
+used for this value. Although this value currently serves no practical
+purpose within the operations of the Swarm node, the handshake *MUST*
+fail if the string cannot be parsed as a valid Enode ID. 
+
+We here add the following definitions:
+
+    ENODEPREFIX = "enode://"
+    PUBLICKEYHEX = "04" 64HEXDIG
+    HOST = IP / FQDN
+    UNDERLAYADDRESS = ENODEPREFIX PUBLICKEYHEX "@" HOST ":" PORT
+    ADDRESSPAIR=2#2list(OVERLAYADDRESS UNDERLAYADDRESS)
+
+# protocols
+
+Swarm protocols require a p2p transport protocol.
+
+At the time of writing, the Swarm reference implementation depends on
+the devp2p protocol, including its RLPX wire format and encryption
+scheme.  Detailing the concepts of `devp2p` and `RLP(X)` as such is out
+of scope of this document.
+
+Data payloads will be defined in ABNF format. Reference examples to
+verify the correct `RLP` encoded form of the data will also be included.
 
 We define the following mappings from ABNF data type definitions to RLP
 data types:
 
-|type|description|
-|:---|:---|
-|BOOL|is encoded as an RLP encoded integer with length of one byte|
-|OCTET|is encoded as an RLP encoded integer with length of one byte|
-|TIMESTAMP|is encoded as an RLP encoded variable length integer|
-|\%x\#\#|hexadecimal literals are encoded as encoded integers with length of one byte, corresponding to its hexadecimal (not its string) value|
-|LIST|as defined in [1.1.3] will be RLP encoded as RLP lists|
+  - BOOL  
+    is encoded as an RLP encoded integer with length of one byte
+
+  - OCTET  
+    is encoded as an RLP encoded integer with length of one byte
+
+  - TIMESTAMP  
+    is encoded as an RLP encoded variable length integer
+
+  - %x\#\#  
+    hexadecimal literals are encoded as encoded integers with length of
+    one byte, corresponding to its hexadecimal (not its string) value
+
+  - LIST  
+    as defined in [1.1.3](#abnf-list-definition) will be RLP encoded as
+    RLP lists.
 
 All other data is encoded as RLP lists.
 
-The outermost element of a serialization is always a LIST item [^1]
+The outermost element of a serialization is always a LIST item \[1\]
 
-### example
+## example
 
 A message structure with only one field of `3OCTET` data will in
 *reality* be `LIST(3OCTET)`. If the data is `0x666f6f` it will serialize
 to `0xc4 83 66 6f 6f`, which breaks down to:
 
-```
-LIST:   0xc4 (list, 4 bytes long)
-3OCTET: 0x83 (string, 3 bytes long)
-data:   0x66 0x6f 0x6f
-```
+    LIST:   0xc4 (list, 4 bytes long)
+    3OCTET: 0x83 (string, 3 bytes long)
+    data:   0x66 0x6f 0x6f
 
-## Backwards Compatibility
-
-There are no compatibility issues.
-
-## Test Cases
-
-There are no relevant test cases.
-
-## Implementation
-
-Any future SWIP defining Swarm protocols.
-
-## Copyright
-
-Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+1.  This is due to the fact that the reference implementation is written
+    in golang, and the default RLP deserialization of golang structs
+    treats the struct itself as a list.

--- a/SWIPs/swip-data-types-descriptions.md
+++ b/SWIPs/swip-data-types-descriptions.md
@@ -1,3 +1,36 @@
+---
+SWIP: <to be assigned>
+title: Swarm node implementer spec - 
+author: Louis Holbrook @nolash <dev@holbrook.no>
+status: Draft
+type: Track Specs
+created: 2019-
+---
+
+## Abstract
+
+This SWIP is a part of a general specification of a Swarm node. The SWIP system is used for convenience only.
+
+## Motivation
+
+Enable other implementations of the swarm node.
+
+## Backwards Compatibility
+
+N/A
+
+## Test Cases
+
+N/A
+
+## Implementation
+
+N/A
+
+## Copyright
+
+Copyright and related rights waived via CC0
+
 # introduction
 
 ## data representations
@@ -101,7 +134,7 @@ data types:
 
 All other data is encoded as RLP lists.
 
-The outermost element of a serialization is always a LIST item \[1\]
+The outermost element of a serialization is always a LIST item [1]
 
 ## example
 
@@ -112,6 +145,7 @@ to `0xc4 83 66 6f 6f`, which breaks down to:
     LIST:   0xc4 (list, 4 bytes long)
     3OCTET: 0x83 (string, 3 bytes long)
     data:   0x66 0x6f 0x6f
+
 
 1.  This is due to the fact that the reference implementation is written
     in golang, and the default RLP deserialization of golang structs


### PR DESCRIPTION
This is the SWIP markdown rendering of the [data.latex](https://github.com/ethersphere/node-implementer-spec/blob/master/src/data.latex) document from the node-implementer-spec.

It defines the format in which datatypes will be described, and defines basic data type components required to build the respective protocol descriptions for Swarm.

----


As we are using the SWIP review process for these submissions, the documents are formatted to the SWIP template. It is, however, not an _improvement proposal_ and thus only the **Specification** section is relevant.

Also, please consider these submissions in the general context of a full specification document. For this reason, internal document reference links in the markdown douments may very well not point to anywhere.

If the full context is needed, please see the PDF build of current [node implementer spec master branch](https://github.com/ethersphere/node-implementer-spec) state, which can be found on [this swarm-feed address](https://swarm-gateways.net/bzz:/dcad67ce1b19aa80d8bb2c1e5c2244c2e67f3f0f894cf863ed5522d0943e4c14/)