### PR TITLE
Add capabilities data type and role description

### DIFF
--- a/SWIPs/swip-capabilities.md
+++ b/SWIPs/swip-capabilities.md
@@ -1,0 +1,54 @@
+---
+SWIP: <to be assigned>
+title: Swarm node implementer spec - 
+author: Louis Holbrook @nolash <dev@holbrook.no>
+status: Draft
+type: Track Specs
+created: 2019-08-23
+---
+
+## Abstract
+
+This SWIP is a part of a general specification of a Swarm node. The SWIP system is used for convenience only.
+
+## Motivation
+
+Enable other implementations of the swarm node.
+
+## Backwards Compatibility
+
+N/A
+
+## Test Cases
+
+N/A
+
+## Implementation
+
+N/A
+
+## Copyright
+
+Copyright and related rights waived via CC0
+
+## Specification
+
+### Capabilities
+
+Swarm nodes rely on the underlying transport to negotiate which
+protocols the node understands. If a protocol name and version pair
+matches, the protocol execution loop must be started.
+
+Additionally, the `Capabilities` mechanism enables peers to communicate
+additional detail about what features within the modules the protocols
+represent are enabled, and how they work. It is up to individual modules
+running in the node to determine whether and how differences in
+`Capabilities` cause incompatibilities.
+
+`Capabilities` are transmitted as collections of key-value pairs of
+numerical id and bitvectors. They are included in the bzz handshake
+protocol. [\[sec:bzz-handshake\]](#sec:bzz-handshake)
+
+    CAPABILITYID    = UINT64
+    CAPABILITY  = LIST(LIST(CAPABILITYID *8BIT))
+    CAPABILITIES    = LIST(LIST(*CAPABILITY))


### PR DESCRIPTION
Adds a general description of the role of capabilities, and the high level data representation of them as they are communicated between nodes.

This description **SHOULD** reflect the current implementation on the master branch, aswell as the golang reference implementation SWIP on the same topic in https://github.com/ethersphere/SWIPs/pull/12 

----


As we are using the SWIP review process for these submissions, the documents are formatted to the SWIP template. It is, however, not an _improvement proposal_ and thus only the **Specification** section is relevant.

Also, please consider these submissions in the general context of a full specification document. For this reason, internal document reference links in the markdown douments may very well not point to anywhere.

If the full context is needed, please see the PDF build of current [node implementer spec master branch](https://github.com/ethersphere/node-implementer-spec) state, which can be found on [this swarm-feed address](https://swarm-gateways.net/bzz:/dcad67ce1b19aa80d8bb2c1e5c2244c2e67f3f0f894cf863ed5522d0943e4c14/)