### PR TITLE
SWIP-XXXX: Swarm Provider API (window.swarm)

### DIFF
--- a/SWIPs/SWIP-draft_swarm_provider_api.md
+++ b/SWIPs/SWIP-draft_swarm_provider_api.md
@@ -1,0 +1,545 @@
+---
+SWIP: <to be assigned>
+title: Swarm Provider API (`window.swarm`)
+author: Florian Glatz (@heckerhut)
+discussions-to: https://discord.com/channels/799027393297514537/1239813439136993280
+status: Draft
+type: Standards Track
+category: Interface
+created: 2026-04-03
+---
+
+## Simple Summary
+
+A standard JavaScript API (`window.swarm`) that enables web pages to request access to a user's Swarm node for publishing data, uploading files, and managing mutable feeds — with user consent and origin-scoped permissions.
+
+## Abstract
+
+This SWIP defines a browser-injected JavaScript provider object (`window.swarm`) that allows web applications to interact with a user's local Swarm (Bee) node. The API follows the request/response pattern established by [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) for Ethereum providers, adapted for Swarm's publishing and feed primitives. It specifies seven RPC methods covering connection, capability discovery, data/file publishing, upload tracking, and mutable feed management. The provider includes a permission model with explicit user consent, origin isolation, and upload size limits.
+
+## Motivation
+
+Today, publishing to Swarm from a web application requires either:
+
+1. Direct HTTP calls to a locally running Bee node API (exposing the full API surface, including administrative endpoints, to any web page that can reach `localhost`), or
+2. Server-side publishing infrastructure (defeating the purpose of decentralized hosting).
+
+Neither approach is suitable for a user-sovereign web. Users need a way to grant web applications controlled, permissioned access to Swarm publishing capabilities — similar to how `window.ethereum` ([EIP-1193](https://eips.ethereum.org/EIPS/eip-1193)) lets web applications interact with a user's Ethereum wallet without exposing private keys.
+
+Without a standard, each Swarm-enabled browser or extension will invent its own API. This fragments the ecosystem: dApp developers must write implementation-specific code, and users can't switch clients without breaking functionality. A standard `window.swarm` provider ensures interoperability across implementations.
+
+### Design Goals
+
+- **User consent first.** No operation executes without explicit permission.
+- **Minimal surface.** Only publishing and feeds are exposed — not administrative, debug, or staking endpoints.
+- **Origin isolation.** Each web origin gets isolated permissions and feed identities.
+- **Implementation freedom.** The spec defines the interface, not how the host manages nodes, keys, or storage internally.
+
+## Specification
+
+### Provider Object
+
+Conforming implementations MUST inject a `window.swarm` object into the JavaScript context of web pages. The object MUST be available before the page's `DOMContentLoaded` event fires.
+
+#### Detection
+
+```javascript
+if (typeof window.swarm !== 'undefined') {
+  // Swarm provider is available
+}
+```
+
+#### Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `isFreedomBrowser` | `boolean` | **(OPTIONAL, implementation-specific)** Implementations MAY include a boolean property identifying themselves. This is NOT part of the standard interface and MUST NOT be relied upon for feature detection. Use `swarm_getCapabilities` instead. |
+
+> **Note:** Future versions of this specification may define a standard `isSwarmProvider` property or a capability-based detection mechanism.
+
+### Request Interface
+
+The provider MUST expose a `request` method:
+
+```javascript
+window.swarm.request({ method: string, params?: object }): Promise<any>
+```
+
+- `method` — (Required) A string identifying the RPC method to invoke.
+- `params` — (Optional) A plain object containing method-specific parameters.
+
+The method MUST return a `Promise` that resolves with the method's result, or rejects with an error object.
+
+### Convenience Methods
+
+Implementations SHOULD expose convenience wrappers for each standard method:
+
+```javascript
+window.swarm.requestAccess()                     // swarm_requestAccess
+window.swarm.getCapabilities()                    // swarm_getCapabilities
+window.swarm.publishData({ data, contentType })   // swarm_publishData
+window.swarm.publishFiles({ files })              // swarm_publishFiles
+window.swarm.getUploadStatus({ tagUid })          // swarm_getUploadStatus
+window.swarm.createFeed({ name })                 // swarm_createFeed
+window.swarm.updateFeed({ feedId, reference })    // swarm_updateFeed
+```
+
+These MUST be equivalent to calling `window.swarm.request()` with the corresponding method name.
+
+### Events
+
+The provider MUST support event subscription:
+
+```javascript
+window.swarm.on(event: string, handler: Function): this
+window.swarm.removeListener(event: string, handler: Function): this
+window.swarm.removeAllListeners(event?: string): this
+```
+
+#### Standard Events
+
+| Event | Data | Description |
+|---|---|---|
+| `connect` | `{ origin: string }` | Emitted when the user grants access. |
+| `disconnect` | `{ origin: string }` | Emitted when the user revokes access or the provider disconnects. |
+
+### Error Format
+
+Errors MUST follow the [JSON-RPC 2.0 error format](https://www.jsonrpc.org/specification#error_object):
+
+```javascript
+{
+  code: number,
+  message: string,
+  data?: any
+}
+```
+
+#### Standard Error Codes
+
+| Code | Name | Description |
+|---|---|---|
+| 4001 | User Rejected | The user denied the request. |
+| 4100 | Unauthorized | The origin has not been granted access. Call `swarm_requestAccess` first. |
+| 4200 | Unsupported Method | The requested method is not recognized. |
+| 4900 | Node Unavailable | The Swarm node is not running, not ready, or lacks usable postage stamps. |
+| -32602 | Invalid Params | Missing or invalid method parameters. |
+| -32603 | Internal Error | An unexpected error occurred in the provider. |
+
+Error codes 4001, 4100, 4200, and 4900 are aligned with the [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) and [EIP-1474](https://eips.ethereum.org/EIPS/eip-1474) error code ranges.
+
+---
+
+### Methods
+
+#### `swarm_requestAccess`
+
+Requests the user's permission to interact with their Swarm node from this origin. Implementations MUST present a user-visible consent prompt. The user MUST be able to deny access.
+
+**Params:** None.
+
+**Result:**
+
+```javascript
+{
+  connected: true,
+  origin: string,          // The normalized origin that was granted access
+  capabilities: string[]   // e.g. ["publish"]
+}
+```
+
+**Errors:** `4001` if the user rejects.
+
+**Behavior:**
+- Calling `swarm_requestAccess` when already connected SHOULD return the existing connection state without re-prompting.
+- After a successful `swarm_requestAccess`, the provider MUST emit a `connect` event.
+
+---
+
+#### `swarm_getCapabilities`
+
+Returns the current capabilities of the provider for this origin. Does NOT require prior access — can be called before `swarm_requestAccess` for feature detection.
+
+**Params:** None.
+
+**Result:**
+
+```javascript
+{
+  canPublish: boolean,     // true if connected AND node is ready
+  reason: string | null,   // null if canPublish is true, otherwise a reason code
+  limits: {
+    maxDataBytes: number,  // Maximum payload size for swarm_publishData
+    maxFilesBytes: number, // Maximum total size for swarm_publishFiles
+    maxFileCount: number   // Maximum number of files per swarm_publishFiles call
+  }
+}
+```
+
+**Reason codes:**
+
+| Code | Meaning |
+|---|---|
+| `"not-connected"` | Origin has not called `swarm_requestAccess`. |
+| `"node-stopped"` | Bee node is not running. |
+| `"ultra-light-mode"` | Node is in ultra-light mode (browse only, cannot publish). |
+| `"node-not-ready"` | Node is running but not yet synced/ready. |
+| `"no-usable-stamps"` | No postage stamps with remaining capacity. |
+
+---
+
+#### `swarm_publishData`
+
+Upload a single blob of data to Swarm.
+
+**Params:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `data` | `string \| Uint8Array \| ArrayBuffer` | Yes | The content to upload. |
+| `contentType` | `string` | Yes | MIME type (e.g. `"text/html"`, `"application/json"`). |
+| `name` | `string` | No | Display name for the upload. |
+
+**Result:**
+
+```javascript
+{
+  reference: string,   // 64-character hex Swarm reference
+  bzzUrl: string       // "bzz://<reference>"
+}
+```
+
+**Errors:** `4100` if not connected, `4900` if node unavailable, `-32602` if params invalid or payload exceeds `maxDataBytes`.
+
+**Behavior:**
+- Implementations SHOULD prompt the user for per-publish consent unless the user has opted into auto-approve for this origin.
+- The implementation selects an appropriate postage batch automatically — dApps do not manage batches.
+- Uploads MUST be pinned on the local node.
+
+---
+
+#### `swarm_publishFiles`
+
+Upload a collection of files as a Swarm manifest (directory).
+
+**Params:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `files` | `Array<FileEntry>` | Yes | Array of file objects. |
+| `indexDocument` | `string` | No | Path of the default document (e.g. `"index.html"`). Must match an entry in `files`. |
+
+**FileEntry:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `path` | `string` | Yes | Virtual path in the manifest (e.g. `"index.html"`, `"assets/style.css"`). |
+| `bytes` | `Uint8Array \| ArrayBuffer` | Yes | File content. |
+| `contentType` | `string` | No | MIME type. Implementation MAY infer from path if omitted. |
+
+**Path validation rules:**
+- Must be a non-empty string, maximum 256 characters.
+- No backslashes, no leading slash, no empty segments, no `.` or `..` segments.
+- No control characters (code points < 32).
+- Paths must be unique within the `files` array.
+
+**Result:**
+
+```javascript
+{
+  reference: string,     // 64-character hex Swarm reference
+  bzzUrl: string,        // "bzz://<reference>"
+  tagUid: number | null  // Upload tag for progress tracking (if supported)
+}
+```
+
+**Errors:** `4100` if not connected, `4900` if node unavailable, `-32602` if params invalid, files exceed `maxFileCount`, or total size exceeds `maxFilesBytes`.
+
+---
+
+#### `swarm_getUploadStatus`
+
+Query the upload progress of a previously initiated file upload.
+
+**Params:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `tagUid` | `number` | Yes | The tag ID returned by `swarm_publishFiles`. |
+
+**Result:**
+
+```javascript
+{
+  tagUid: number,
+  split: number,     // Total chunks
+  seen: number,      // Chunks seen by the node
+  stored: number,    // Chunks stored locally
+  sent: number,      // Chunks dispatched to the network
+  synced: number,    // Chunks fully replicated
+  progress: number,  // 0-100 percentage (based on sent/split)
+  done: boolean      // true when all chunks have been sent
+}
+```
+
+**Errors:** `4100` if not connected or tag not owned by this origin, `-32602` if `tagUid` invalid.
+
+**Security:** Implementations MUST enforce origin-scoped tag ownership. A page MUST NOT be able to query upload status for tags created by a different origin. This prevents cross-origin upload snooping.
+
+---
+
+#### `swarm_createFeed`
+
+Create a mutable Swarm feed with a stable `bzz://` URL.
+
+Feeds allow web applications to maintain updatable content at a fixed address. The feed manifest provides a permanent `bzz://` URL that always resolves to the latest update.
+
+**Params:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Feed identifier, unique per origin. Max 64 chars, no `/`, no control chars. |
+
+**Result:**
+
+```javascript
+{
+  feedId: string,              // The feed name (same as input)
+  owner: string,               // Ethereum address of the signing key
+  topic: string,               // Hex-encoded topic hash
+  manifestReference: string,   // 64-character hex reference to the feed manifest
+  bzzUrl: string,              // "bzz://<manifestReference>"
+  identityMode: string         // "app-scoped" or "bee-wallet"
+}
+```
+
+**Errors:** `4100` if not connected or feed access not granted, `4900` if node unavailable, `-32602` if name invalid.
+
+**Behavior:**
+- Creating a feed that already exists MUST be idempotent — return the existing feed's metadata.
+- Implementations MUST support at least one feed identity mode:
+  - **`app-scoped`** (RECOMMENDED default): A dedicated signing key derived per-origin. The key is never funded and cannot sign transactions. This provides origin isolation — one dApp cannot impersonate another's feeds.
+  - **`bee-wallet`**: The node's main Bee wallet key. Useful when the dApp needs feeds signed by a known, funded identity.
+- The identity mode choice MAY be presented to the user during the feed permission prompt.
+- Feed creation requires a separate permission grant beyond basic connection access. Implementations SHOULD prompt users specifically for feed access.
+
+**Feed Topic Derivation:**
+
+The topic for a feed MUST be derived from the normalized origin and the feed name:
+
+```
+topic = keccak256(normalizedOrigin + "/" + feedName)
+```
+
+This ensures feeds are origin-scoped at the protocol level — two different origins using the same feed name produce different topics.
+
+---
+
+#### `swarm_updateFeed`
+
+Update a feed to point at a new content reference.
+
+**Params:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `feedId` | `string` | Yes | Feed name (as returned by `swarm_createFeed`). |
+| `reference` | `string` | Yes | 64-character hex Swarm reference to point the feed at. |
+
+**Result:**
+
+```javascript
+{
+  feedId: string,    // The feed name
+  reference: string, // The new content reference
+  bzzUrl: string     // "bzz://<manifestReference>" (stable feed URL)
+}
+```
+
+**Errors:** `4100` if not connected or feed access not granted, `4900` if node unavailable, `-32602` if params invalid or feed doesn't exist.
+
+---
+
+### Permission Model
+
+#### Origin Normalization
+
+Implementations MUST normalize the requesting page's origin to a stable, content-addressed root identity. For decentralized web contexts where pages are served via local gateways, the HTTP origin (e.g., `http://127.0.0.1:1633`) does NOT represent the content's identity.
+
+The normalization rules are:
+
+| Display URL | Normalized Origin |
+|---|---|
+| `ens://myapp.eth/#/path` | `myapp.eth` |
+| `myapp.eth/blog` | `myapp.eth` |
+| `bzz://abc123def.../page` | `bzz://abc123def...` |
+| `ipfs://QmABC.../docs` | `ipfs://QmABC...` |
+| `ipns://host/guide` | `ipns://host` |
+| `rad://z123.../tree` | `rad://z123...` |
+| `https://app.example.com/page` | `https://app.example.com` |
+
+The key insight: the origin is derived from the **user-visible URL** (the address bar), not from `window.location` which reflects the internal gateway routing.
+
+#### Permission Lifecycle
+
+1. **Connection:** Granted via `swarm_requestAccess`. Persisted per-origin.
+2. **Publish:** Each `swarm_publishData`/`swarm_publishFiles` call MAY require per-operation user approval, unless the user has opted into auto-approve for this origin.
+3. **Feeds:** Feed operations (`swarm_createFeed`, `swarm_updateFeed`) require an additional feed-specific permission grant, separate from the connection permission.
+4. **Disconnection:** The user can revoke access at any time. The provider MUST emit a `disconnect` event and reject subsequent requests with error code `4100`.
+
+#### Auto-Approve (OPTIONAL)
+
+Implementations MAY offer users the option to auto-approve publish and/or feed operations for trusted origins. When auto-approve is active:
+- The implementation MUST still enforce all validation, size limits, and pre-flight checks.
+- The implementation SHOULD provide a visual indicator that auto-approve is active.
+- The user MUST be able to revoke auto-approve at any time.
+
+---
+
+### Limits
+
+Implementations MUST enforce upload size and file count limits. The limits MUST be discoverable via `swarm_getCapabilities`. Recommended defaults:
+
+| Limit | Recommended Default |
+|---|---|
+| `maxDataBytes` | 10 MB (10,485,760 bytes) |
+| `maxFilesBytes` | 50 MB (52,428,800 bytes) |
+| `maxFileCount` | 100 files |
+
+Implementations MAY use different limits but MUST report them accurately in `swarm_getCapabilities`.
+
+---
+
+## Rationale
+
+### Why EIP-1193 style?
+
+The `window.ethereum` pattern ([EIP-1193](https://eips.ethereum.org/EIPS/eip-1193)) is well-understood by web3 developers. By following the same request/response pattern and reusing compatible error codes, we minimize the learning curve and allow existing tooling patterns (event listeners, promise-based flows, error handling) to transfer directly.
+
+### Why not expose the full Bee API?
+
+Exposing the full Bee HTTP API to web pages would be a security risk — it includes administrative endpoints (staking, chequebook management, debug APIs) that should never be accessible to arbitrary web content. The provider API exposes only publishing and feed primitives, with user consent gating every operation.
+
+### Why origin normalization?
+
+In decentralized web browsers, all content from IPFS, Swarm, ENS, etc. is typically served through a local gateway at `127.0.0.1`. Using `window.location.origin` would collapse all dApps into a single permission scope. Origin normalization uses the user-visible URL to derive the content's true identity, providing meaningful per-dApp isolation.
+
+### Why app-scoped feed identities?
+
+Without app-scoped identities, any dApp with feed permission could create feeds signed by the user's main wallet key — making feeds from different dApps indistinguishable and creating impersonation risks. App-scoped keys (derived per-origin from the user's master key) provide cryptographic isolation: each dApp's feeds are signed by a unique key that the dApp cannot extract.
+
+### Why separate feed permissions?
+
+Feeds involve key material (signing) and have long-term implications (the feed URL is permanent, updates are irrevocable). This warrants a separate, more deliberate permission grant beyond "allow this site to upload data."
+
+## Backwards Compatibility
+
+This SWIP introduces a new API surface. There are no backwards compatibility concerns as no prior standard for `window.swarm` exists. Implementations that predate this specification SHOULD migrate to conform to these interfaces.
+
+Web pages that do not use `window.swarm` are unaffected. The provider MUST NOT modify any existing browser APIs or globals.
+
+## Test Cases
+
+### Detection
+
+```javascript
+// Provider available
+assert(typeof window.swarm !== 'undefined');
+assert(typeof window.swarm.request === 'function');
+```
+
+### Connection Flow
+
+```javascript
+// Request access (user approves)
+const result = await window.swarm.requestAccess();
+assert(result.connected === true);
+assert(typeof result.origin === 'string');
+assert(Array.isArray(result.capabilities));
+
+// Capabilities reflect connection
+const caps = await window.swarm.getCapabilities();
+assert(caps.canPublish === true || typeof caps.reason === 'string');
+```
+
+### Publish Data
+
+```javascript
+const result = await window.swarm.publishData({
+  data: '<h1>Hello Swarm</h1>',
+  contentType: 'text/html',
+  name: 'greeting',
+});
+assert(/^[0-9a-f]{64}$/.test(result.reference));
+assert(result.bzzUrl === `bzz://${result.reference}`);
+```
+
+### Publish Files
+
+```javascript
+const encoder = new TextEncoder();
+const result = await window.swarm.publishFiles({
+  files: [
+    { path: 'index.html', bytes: encoder.encode('<h1>Hello</h1>'), contentType: 'text/html' },
+    { path: 'style.css', bytes: encoder.encode('body { color: red; }'), contentType: 'text/css' },
+  ],
+  indexDocument: 'index.html',
+});
+assert(/^[0-9a-f]{64}$/.test(result.reference));
+```
+
+### Feed Lifecycle
+
+```javascript
+// Create feed
+const feed = await window.swarm.createFeed({ name: 'my-blog' });
+assert(feed.feedId === 'my-blog');
+assert(/^[0-9a-f]{64}$/.test(feed.manifestReference));
+
+// Publish content, then update feed
+const content = await window.swarm.publishData({
+  data: '<h1>Post #1</h1>',
+  contentType: 'text/html',
+});
+const updated = await window.swarm.updateFeed({
+  feedId: 'my-blog',
+  reference: content.reference,
+});
+assert(updated.bzzUrl === feed.bzzUrl); // Same stable URL
+```
+
+### Error Handling
+
+```javascript
+// Calling without access
+try {
+  await window.swarm.publishData({ data: 'test', contentType: 'text/plain' });
+  assert.fail('Should have thrown');
+} catch (err) {
+  assert(err.code === 4100); // Unauthorized
+}
+
+// Invalid params
+try {
+  await window.swarm.publishData({}); // missing data and contentType
+  assert.fail('Should have thrown');
+} catch (err) {
+  assert(err.code === -32602); // Invalid params
+}
+```
+
+## Implementation
+
+A reference implementation exists in [Freedom Browser](https://github.com/solardev-xyz/freedom-browser) (PR [#19](https://github.com/solardev-xyz/freedom-browser/pull/19)):
+
+- **Provider injection:** [`src/main/webview-preload.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing/src/main/webview-preload.js) — `window.swarm` object injected into webview page context
+- **Main-process enforcement:** [`src/main/swarm/swarm-provider-ipc.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing/src/main/swarm/swarm-provider-ipc.js) — method dispatch, validation, origin enforcement
+- **Publishing:** [`src/main/swarm/publish-service.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing/src/main/swarm/publish-service.js) — data and file uploads via `bee-js`
+- **Feeds:** [`src/main/swarm/feed-service.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing/src/main/swarm/feed-service.js) — feed creation and updates
+- **Permissions:** [`src/main/swarm/swarm-permissions.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing/src/main/swarm/swarm-permissions.js) — origin-scoped permission store
+- **Origin normalization:** [`src/shared/origin-utils.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing/src/shared/origin-utils.js) — dweb-aware origin extraction
+- **Test page:** [`docs/swarm-provider-test/index.html`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing/docs/swarm-provider-test/index.html) — interactive test harness
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/SWIPs/swip-draft_provider_api.md
+++ b/SWIPs/swip-draft_provider_api.md
@@ -637,7 +637,7 @@ A reference implementation exists in [Freedom Browser](https://github.com/solard
 - **Origin normalization:** [`src/shared/origin-utils.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing-updated/src/shared/origin-utils.js) — dweb-aware origin extraction
 - **Test page:** [`docs/swarm-provider-test/index.html`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing-updated/docs/swarm-provider-test/index.html) — interactive test harness
 
-A reference dApp consuming this API exists in [Swarmit](https://github.com/solardev-xyz/swarmit), a decentralized message board that uses `swarm_requestAccess`, `swarm_publishData`, `swarm_createFeed`, and `swarm_updateFeed` for its full publishing pipeline.
+A reference dApp consuming this API exists in [Swarmit](https://github.com/flotob/swarmit), a decentralized message board that uses `swarm_requestAccess`, `swarm_publishData`, `swarm_createFeed`, and `swarm_updateFeed` for its full publishing pipeline.
 
 ## Copyright
 

--- a/SWIPs/swip-draft_provider_api.md
+++ b/SWIPs/swip-draft_provider_api.md
@@ -11,11 +11,11 @@ created: 2026-04-03
 
 ## Simple Summary
 
-A standard JavaScript API (`window.swarm`) that enables web pages to request access to a user's Swarm node for publishing data, uploading files, managing mutable feeds, reading/writing indexed feed entries, and introspecting their own feed records — with user consent and origin-scoped permissions.
+A standard JavaScript API (`window.swarm`) that enables web pages to request access to a user's Swarm node for publishing data, uploading files, managing mutable feeds, reading/writing indexed feed entries, introspecting their own feed records, and working with low-level chunk primitives — with user consent and origin-scoped permissions.
 
 ## Abstract
 
-This SWIP defines a browser-injected JavaScript provider object (`window.swarm`) that allows web applications to interact with a user's local Swarm (Bee) node. The API follows the request/response pattern established by [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) for Ethereum providers, adapted for Swarm's publishing and feed primitives. It specifies ten RPC methods covering connection, capability discovery, data/file publishing, upload tracking, mutable feed management, indexed feed entry read/write, and origin-scoped feed introspection. The provider includes a permission model with explicit user consent, origin isolation, and upload size limits. Read-only methods that operate on public Swarm data — including feed entry reads and the calling origin's own feed introspection — do not require a connection grant.
+This SWIP defines a browser-injected JavaScript provider object (`window.swarm`) that allows web applications to interact with a user's local Swarm (Bee) node. The API follows the request/response pattern established by [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) for Ethereum providers, adapted for Swarm's publishing, feed, and chunk primitives. It specifies fifteen RPC methods covering connection, capability discovery, data/file publishing, upload tracking, mutable feed management, indexed feed entry read/write, origin-scoped feed introspection, low-level chunk primitives (content-addressed and single-owner), and signing-identity disclosure. The provider includes a permission model with explicit user consent, origin isolation, and upload size limits. Read-only methods that operate on public Swarm data — including feed entry reads, chunk reads, and the calling origin's own feed introspection — do not require a connection grant but MUST be rate-limited per origin.
 
 ## Motivation
 
@@ -30,8 +30,8 @@ Without a standard, each Swarm-enabled browser or extension will invent its own 
 
 ### Design Goals
 
-- **User consent first.** No operation executes without explicit permission.
-- **Minimal surface.** Only publishing and feeds are exposed — not administrative, debug, or staking endpoints.
+- **User consent first.** No write, signing, or other operation that consumes user resources executes without consent or explicit resource controls. Read-only operations on public Swarm data are ungated but rate-limited per origin.
+- **Minimal surface.** Only the data plane — not administrative, debug, or staking endpoints.
 - **Origin isolation.** Each web origin gets isolated permissions and feed identities.
 - **Implementation freedom.** The spec defines the interface, not how the host manages nodes, keys, or storage internally.
 
@@ -73,16 +73,21 @@ The method MUST return a `Promise` that resolves with the method's result, or re
 Implementations MUST expose convenience wrappers for each standard method:
 
 ```javascript
-window.swarm.requestAccess()                     // swarm_requestAccess
-window.swarm.getCapabilities()                    // swarm_getCapabilities
-window.swarm.publishData({ data, contentType })   // swarm_publishData
-window.swarm.publishFiles({ files })              // swarm_publishFiles
-window.swarm.getUploadStatus({ tagUid })          // swarm_getUploadStatus
-window.swarm.createFeed({ name })                 // swarm_createFeed
-window.swarm.updateFeed({ feedId, reference })    // swarm_updateFeed
-window.swarm.writeFeedEntry({ name, data })       // swarm_writeFeedEntry
-window.swarm.readFeedEntry({ name, owner })       // swarm_readFeedEntry
-window.swarm.listFeeds()                          // swarm_listFeeds
+window.swarm.requestAccess()                              // swarm_requestAccess
+window.swarm.getCapabilities()                             // swarm_getCapabilities
+window.swarm.publishData({ data, contentType })            // swarm_publishData
+window.swarm.publishFiles({ files })                       // swarm_publishFiles
+window.swarm.getUploadStatus({ tagUid })                   // swarm_getUploadStatus
+window.swarm.createFeed({ name })                          // swarm_createFeed
+window.swarm.updateFeed({ feedId, reference })             // swarm_updateFeed
+window.swarm.writeFeedEntry({ name, data })                // swarm_writeFeedEntry
+window.swarm.readFeedEntry({ name, owner })                // swarm_readFeedEntry
+window.swarm.listFeeds()                                   // swarm_listFeeds
+window.swarm.publishChunk({ data })                        // swarm_publishChunk
+window.swarm.readChunk({ reference })                      // swarm_readChunk
+window.swarm.writeSingleOwnerChunk({ identifier, data })   // swarm_writeSingleOwnerChunk
+window.swarm.readSingleOwnerChunk({ owner, identifier })   // swarm_readSingleOwnerChunk
+window.swarm.getSigningIdentity()                          // swarm_getSigningIdentity
 ```
 
 Each convenience method MUST be equivalent to calling `window.swarm.request()` with the corresponding method name and parameters.
@@ -121,7 +126,7 @@ Errors MUST follow the [JSON-RPC 2.0 error format](https://www.jsonrpc.org/speci
 | Code | Name | Description |
 |---|---|---|
 | 4001 | User Rejected | The user denied the request. |
-| 4100 | Unauthorized | The origin has not been granted access. Call `swarm_requestAccess` first. |
+| 4100 | Unauthorized | The origin is not authorized for the requested operation, or required consent cannot be obtained in this context. Covers: origin has not called `swarm_requestAccess`; feed-permission prompt cannot be surfaced; tag ownership mismatch in `swarm_getUploadStatus`; access was previously revoked. |
 | 4200 | Unsupported Method | The requested method is not recognized. |
 | 4900 | Node Unavailable | The Swarm node is not running, not ready, or lacks usable postage stamps. |
 | -32602 | Invalid Params | Missing or invalid method parameters. |
@@ -139,9 +144,16 @@ For `-32602` (Invalid Params) errors, implementations SHOULD include a `data.rea
 | `entry_not_found` | `swarm_readFeedEntry` | No entry at the requested index. |
 | `feed_not_found` | `swarm_readFeedEntry`, `swarm_writeFeedEntry` | Feed not found in local store or does not exist. |
 | `index_already_exists` | `swarm_writeFeedEntry` | An entry already exists at the explicit index (overwrite protection). |
-| `payload_too_large` | `swarm_publishData`, `swarm_writeFeedEntry` | Payload exceeds the maximum allowed size. |
+| `payload_too_large` | `swarm_publishData`, `swarm_writeFeedEntry`, `swarm_publishChunk`, `swarm_writeSingleOwnerChunk` | Payload exceeds the maximum allowed size. |
 | `invalid_topic` | `swarm_readFeedEntry` | Topic is not a valid 64-character hex string. |
-| `invalid_owner` | `swarm_readFeedEntry` | Owner is missing (when required) or not a valid address. |
+| `invalid_owner` | `swarm_readFeedEntry`, `swarm_readSingleOwnerChunk` | Owner is missing (when required) or not a valid address. |
+| `invalid_reference` | `swarm_readChunk`, `swarm_readSingleOwnerChunk` | Chunk reference is not a valid 64-character hex address. |
+| `invalid_identifier` | `swarm_writeSingleOwnerChunk`, `swarm_readSingleOwnerChunk` | SOC identifier is not a valid 64-character hex string. |
+| `invalid_span` | `swarm_publishChunk`, `swarm_writeSingleOwnerChunk` | Explicit `span` is negative, non-integer, exceeds the 8-byte unsigned range, or is a `number` outside `Number.MAX_SAFE_INTEGER` (use `bigint` for values above 2⁵³ − 1). |
+| `chunk_not_found` | `swarm_readChunk`, `swarm_readSingleOwnerChunk` | No chunk exists at the requested address. |
+| `chunk_type_mismatch` | `swarm_readChunk`, `swarm_readSingleOwnerChunk` | Returned bytes do not validate as the requested chunk type. |
+| `unsupported_option` | All methods accepting `options` | An option field was supplied that the implementation does not recognize. |
+| `rate_limited` | `swarm_readFeedEntry`, `swarm_readChunk`, `swarm_readSingleOwnerChunk`, `swarm_listFeeds` | The calling origin has exceeded the implementation's per-origin rate or bandwidth budget for permission-free reads. |
 
 ---
 
@@ -185,10 +197,11 @@ Returns the current capabilities of the provider for this origin. Does NOT requi
   canPublish: boolean,     // true if connected AND node is ready
   reason: string | null,   // null if canPublish is true, otherwise a reason code
   limits: {
-    maxDataBytes: number,  // Maximum payload size for swarm_publishData and swarm_writeFeedEntry
-    maxFilesBytes: number, // Maximum total size for swarm_publishFiles
-    maxFileCount: number,  // Maximum number of files per swarm_publishFiles call
-    maxPathBytes: number   // Maximum length of a file path in swarm_publishFiles, measured in UTF-8 bytes
+    maxDataBytes: number,         // Maximum payload size for swarm_publishData and swarm_writeFeedEntry
+    maxFilesBytes: number,        // Maximum total size for swarm_publishFiles
+    maxFileCount: number,         // Maximum number of files per swarm_publishFiles call
+    maxPathBytes: number,         // Maximum length of a file path in swarm_publishFiles, measured in UTF-8 bytes
+    maxChunkPayloadBytes: number  // Maximum payload size for swarm_publishChunk and swarm_writeSingleOwnerChunk (4096 by protocol)
   }
 }
 ```
@@ -230,7 +243,7 @@ Upload a single blob of data to Swarm.
 
 > **Note on `bzz://` URLs:** The `bzz://` URI scheme is a Swarm convention for content-addressed references. It is not an IANA-registered scheme. Implementations resolve `bzz://` URLs through a local Bee gateway or native protocol handler.
 
-**Errors:** `4100` if not connected, `4900` if node unavailable, `-32602` if params invalid or payload exceeds `maxDataBytes`.
+**Errors:** `4001` if the user rejects a per-publish prompt. `4100` if not connected. `4900` if node unavailable. `-32602` if params invalid or payload exceeds `maxDataBytes`.
 
 **Behavior:**
 - Implementations SHOULD prompt the user for per-publish consent unless the user has opted into auto-approve for this origin.
@@ -274,7 +287,7 @@ Upload a collection of files as a Swarm manifest (directory).
 }
 ```
 
-**Errors:** `4100` if not connected, `4900` if node unavailable, `-32602` if params invalid, files exceed `maxFileCount`, or total size exceeds `maxFilesBytes`.
+**Errors:** `4001` if the user rejects a per-publish prompt. `4100` if not connected. `4900` if node unavailable. `-32602` if params invalid, files exceed `maxFileCount`, or total size exceeds `maxFilesBytes`.
 
 ---
 
@@ -336,7 +349,7 @@ Feeds allow web applications to maintain updatable content at a fixed address. T
 }
 ```
 
-**Errors:** `4100` if not connected or feed access not granted, `4900` if node unavailable, `-32602` if name invalid.
+**Errors:** `4001` if the user rejects the feed-permission prompt. `4100` if the origin lacks basic connection or the implementation cannot surface a permission prompt. `4900` if node unavailable. `-32602` if name invalid.
 
 **Behavior:**
 - Creating a feed that already exists MUST be idempotent — return the existing feed's metadata.
@@ -380,7 +393,7 @@ Update a feed to point at a new content reference.
 }
 ```
 
-**Errors:** `4100` if not connected or feed access not granted, `4900` if node unavailable, `-32602` if params invalid or feed doesn't exist.
+**Errors:** `4001` if the user rejects a feed-permission prompt this call triggered. `4100` if the origin lacks basic connection or the implementation cannot surface a permission prompt. `4900` if node unavailable. `-32602` if params invalid or feed doesn't exist.
 
 **Behavior:**
 - Writes are serialized per-topic (same mutex as `swarm_writeFeedEntry`). The returned `index` reflects the actual sequence index written.
@@ -411,7 +424,7 @@ The 4 KB SOC body limit is internal to the storage envelope and is NOT a dApp-vi
 }
 ```
 
-**Errors:** `4100` if not connected or feed access not granted, `4900` if node unavailable, `-32602` if params invalid, feed doesn't exist, index is occupied (`index_already_exists`), or payload exceeds `maxDataBytes` (`payload_too_large`).
+**Errors:** `4001` if the user rejects a feed-permission prompt this call triggered. `4100` if the origin lacks basic connection or the implementation cannot surface a permission prompt. `4900` if node unavailable. `-32602` if params invalid, feed doesn't exist, index is occupied (`index_already_exists`), or payload exceeds `maxDataBytes` (`payload_too_large`).
 
 **Behavior:**
 
@@ -466,7 +479,7 @@ const bytes = Uint8Array.from(atob(result.data), c => c.charCodeAt(0))
 const text = new TextDecoder().decode(bytes)
 ```
 
-**Errors:** `4900` if node unreachable, `-32602` if params invalid. Notably does NOT return `4100` — no permission is required to call this method.
+**Errors:** `4900` if node unreachable, `-32602` if params invalid or the calling origin has exceeded its per-origin read budget (`rate_limited`). Notably does NOT return `4100` — no permission is required to call this method.
 
 Structured error reasons in `data.reason`:
 
@@ -475,6 +488,7 @@ Structured error reasons in `data.reason`:
 | `feed_empty` | The feed exists but has no entries written yet (returned for latest-entry reads). |
 | `entry_not_found` | No entry exists at the requested index. |
 | `feed_not_found` | Used `name` without `owner`, but the feed has not been created yet under this origin. |
+| `rate_limited` | The calling origin has exceeded the implementation's per-origin rate or bandwidth budget for permission-free reads. See [Resource Exhaustion](#resource-exhaustion). |
 
 **Behavior:**
 
@@ -514,7 +528,7 @@ This is an introspection method scoped to the calling origin. It does NOT requir
 
 Returns an empty array `[]` for origins with no feeds — including origins that have never granted permission, origins that have granted but not created feeds, and origins whose permission has been revoked.
 
-**Errors:** None expected on the happy path. `-32603` (Internal Error) only on unexpected internal failures (e.g., feed-store read errors).
+**Errors:** None expected on the happy path. `-32602` with `data.reason = "rate_limited"` if the calling origin has exceeded its per-origin read budget (see [Resource Exhaustion](#resource-exhaustion)). `-32603` (Internal Error) only on unexpected internal failures (e.g., feed-store read errors).
 
 **Behavior:**
 
@@ -525,6 +539,187 @@ Returns an empty array `[]` for origins with no feeds — including origins that
   - Symmetric with `swarm_readFeedEntry`: both are read-only operations on data the caller could obtain elsewhere.
 - **`lastUpdated` and `lastReference`** are populated only by `swarm_updateFeed`-style usage. For feeds maintained as journals via `swarm_writeFeedEntry`, both fields stay `null` (those operations do not update the manifest reference).
 - **`bzzUrl`** is a stable convenience built from `manifestReference`. For `swarm_updateFeed`-style feeds it resolves to the latest pointed-at content; for journal-style feeds (where the SOC payload is raw bytes rather than a content reference) the manifest URL has limited utility — applications should use `swarm_readFeedEntry` to read journal contents.
+
+---
+
+### Low-Level Chunk Methods
+
+The methods specified above are *high-level*: they express publishing and feed intent, and the provider translates that intent into Swarm's underlying chunk operations. This section defines the *low-level* tier — direct read and write access to individual Swarm chunks.
+
+Every Swarm data structure is ultimately a graph of chunks: **content-addressed chunks (CACs)** for immutable data, and **Single Owner Chunks (SOCs)** — signed chunks at a caller-chosen address — used as the building block for mutable structures such as feeds. Exposing the chunk layer lets dApps and libraries implement higher-level constructs this specification does not define directly — custom manifests, epoch feeds, access-controlled data, and structures not yet supported natively by Bee — without a revision of this specification for each one.
+
+The chunk tier is **additive**. It does not replace the high-level methods, which carry consent semantics, safety guarantees (e.g. the journal overwrite protection of `swarm_writeFeedEntry`), and an efficient bulk-data path. Applications SHOULD prefer the high-level methods where they fit, and reach for the chunk tier only for primitives the high-level methods do not provide.
+
+**Chunk type is explicit.** Swarm carries no in-band chunk-type tag, and a chunk's 32-byte address does not reveal whether it is a CAC or a SOC; Bee currently distinguishes them heuristically (see [SWIP-67](https://github.com/ethersphere/SWIPs/pull/67) and [bee#5445](https://github.com/ethersphere/bee/pull/5445)). This specification sidesteps that ambiguity by making the chunk type explicit in the **method name** — `swarm_publishChunk`/`swarm_readChunk` operate on CACs, `swarm_writeSingleOwnerChunk`/`swarm_readSingleOwnerChunk` operate on SOCs. The provider never has to guess, and the API does not depend on the resolution of the upstream heuristic.
+
+**Chunk size.** A Swarm chunk payload is at most 4096 bytes. This is a protocol constant, advertised as `maxChunkPayloadBytes` in `swarm_getCapabilities` for completeness, but it is not implementation-configurable.
+
+**Not for bulk data.** Each chunk method call crosses a process boundary and incurs IPC overhead. Uploading large content as thousands of individual `swarm_publishChunk` calls is far slower than `swarm_publishData`, which splits content into a BMT tree in a single node operation. Applications SHOULD use `swarm_publishData`/`swarm_publishFiles` for bulk content and reserve the chunk methods for single chunks and custom structures that cannot be expressed at the high-level tier.
+
+All chunk uploads MUST be pinned on the local node, as with `swarm_publishData`. The implementation selects an appropriate postage batch automatically.
+
+**Type validation on read.** Implementations MUST validate the returned bytes against the requested chunk type using Swarm's standard chunk verification rules — BMT hash recomputation for CACs, SOC signature recovery and `keccak256(identifier_32 || owner_20)` address derivation for SOCs. A mismatch MUST be reported as `chunk_type_mismatch`. See [Implementation Note: Exact-Match Feed Reads](#implementation-note-exact-match-feed-reads) for SOC address derivation and the span-endianness rules; refer to Swarm's chunk-format specification for the canonical byte layout (with [bee-js](https://github.com/ethersphere/bee-js) as a reference implementation).
+
+**Options object.** Several chunk methods accept an optional `options` object. The v1 surface is deliberately narrow — see [Future Extensions](#future-extensions) for the deferred fields and the rationale. Implementations MUST reject any option key they do not recognize with `-32602` and `data.reason = "unsupported_option"`, so that future option additions degrade safely.
+
+---
+
+#### `swarm_publishChunk`
+
+Upload a single content-addressed chunk (CAC).
+
+**Params:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `data` | `string \| Uint8Array \| ArrayBuffer` | Yes | Chunk payload. Strings are encoded as UTF-8. MUST be ≤ `maxChunkPayloadBytes` (4096). |
+| `span` | `number \| bigint` | No | The value committed in the chunk's 8-byte span field. Defaults to the byte length of `data` (always representable as a `number`). Set explicitly only when constructing intermediate nodes of a custom BMT tree. MUST be a non-negative integer fitting in 8 unsigned bytes (`0 ≤ span ≤ 2⁶⁴ − 1`). Pass a `bigint` when the value exceeds `Number.MAX_SAFE_INTEGER` (2⁵³ − 1); a `number` outside the safe-integer range MUST be rejected with `invalid_span`. |
+| `options` | `object` | No | Reserved for future use. No fields are standardized in v1; unknown fields MUST be rejected with `unsupported_option`. |
+
+**Result:**
+
+```javascript
+{
+  reference: string   // 64-character hex chunk address
+}
+```
+
+**Errors:** `4001` if the user rejects a per-publish prompt. `4100` if not connected. `4900` if node unavailable. `-32602` if params invalid (`payload_too_large`, `invalid_span`, `unsupported_option`).
+
+**Behavior:**
+- The chunk address is the BMT hash of `span_8LE || data`. See [Implementation Note: Exact-Match Feed Reads](#implementation-note-exact-match-feed-reads) for the **little-endian** span convention.
+- Subject to the **publish permission tier** — the same per-operation consent / auto-approve as `swarm_publishData`.
+- CACs are immutable; uploading a chunk that already exists is idempotent and returns an identical reference.
+- Chunk payloads are opaque bytes. Per-chunk encryption is the caller's responsibility — the provider stores the bytes as given. (Swarm's encryption primitive lives at the BMT-tree layer, not at single `/chunks` endpoints; see [Future Extensions](#future-extensions).)
+
+---
+
+#### `swarm_readChunk`
+
+Retrieve a single content-addressed chunk by its address. This is a read-only operation on public Swarm data and does NOT require any permission grant — symmetric with `swarm_readFeedEntry`. Any web page MAY call it. Subject to the per-origin rate limits described in [Security Considerations](#resource-exhaustion).
+
+**Params:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `reference` | `string` | Yes | 64-character hex chunk address. |
+| `options` | `object` | No | Reserved for future use. Unknown fields MUST be rejected with `unsupported_option`. |
+
+**Result:**
+
+```javascript
+{
+  data: string,        // Base64-encoded chunk payload (span field stripped)
+  encoding: "base64",
+  span: number | bigint   // Decoded span value; `number` when ≤ Number.MAX_SAFE_INTEGER, `bigint` otherwise
+}
+```
+
+**Errors:** `4900` if node unreachable, `-32602` for invalid params (`invalid_reference`, `unsupported_option`). `data.reason` is `chunk_not_found` if no chunk exists at the address, `chunk_type_mismatch` if the returned bytes do not validate as a CAC at the requested address, or `rate_limited` if the per-origin budget is exceeded.
+
+**Behavior:**
+- Works regardless of node mode; reads consume no stamps. Pre-flight checks MUST be limited to verifying the Bee HTTP API is reachable (same rule as `swarm_readFeedEntry`).
+- Implementations MUST recompute the BMT hash of the returned bytes (over `span_8LE || data`) and reject any chunk whose hash does not equal the requested `reference` (`chunk_type_mismatch`). A returned SOC at the same address — which is structurally possible — MUST be rejected here; the caller intended a CAC and should use `swarm_readSingleOwnerChunk` for SOCs.
+- Implementations MUST distinguish "not found" (HTTP 404) from transient errors (5xx, timeouts). Transient errors MUST propagate as `-32603`, NOT be misclassified as `chunk_not_found`.
+
+---
+
+#### `swarm_writeSingleOwnerChunk`
+
+Write a Single Owner Chunk at a caller-chosen `identifier`, signed by the origin's signing identity. SOCs are the primitive behind every mutable Swarm structure (feeds, epoch feeds, custom mutable references).
+
+**Params:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `identifier` | `string` | Yes | 64-character hex (32-byte) SOC identifier, chosen by the caller. |
+| `data` | `string \| Uint8Array \| ArrayBuffer` | Yes | Payload. Strings encoded as UTF-8. MUST be ≤ `maxChunkPayloadBytes` (4096). |
+| `span` | `number \| bigint` | No | As in `swarm_publishChunk` (same range, same `bigint`-for-out-of-safe-integer-range rule). |
+| `options` | `object` | No | Reserved for future use. Unknown fields MUST be rejected with `unsupported_option`. |
+
+**Result:**
+
+```javascript
+{
+  reference: string,    // 64-character hex SOC address
+  owner: string,        // Checksummed Ethereum address of the signing key
+  identifier: string    // The identifier (echoed)
+}
+```
+
+**Errors:** `4001` if the user rejects a feed-permission prompt this call triggered. `4100` if the origin lacks basic connection or the implementation cannot surface a permission prompt. `4900` if node unavailable. `-32602` if params invalid (`invalid_identifier`, `invalid_span`, `payload_too_large`, `unsupported_option`).
+
+**Behavior:**
+- The provider signs the SOC using the **origin's signing identity** — the same identity established at feed-permission grant time and exposed via `swarm_getSigningIdentity`. There is no caller-supplied `identityMode` parameter in v1 (see [Future Extensions](#future-extensions)). Key material MUST NOT be exposed to the page context (consistent with the feed key-material rules in [Security Considerations](#feed-key-material)).
+- The SOC address is `keccak256(identifier_32 || owner_20)` — see [Implementation Note: Exact-Match Feed Reads](#implementation-note-exact-match-feed-reads).
+- Subject to the **feed permission tier** — SOC writes involve signing and require the feed-access grant, the same grant as `swarm_createFeed`.
+- Because the owner is an origin-scoped key, a dApp can only create SOCs under its own identity. It cannot forge SOCs owned by another origin or by an arbitrary address.
+- **No overwrite guarantee.** The same `(owner, identifier)` pair SHOULD be treated as immutable; the behavior of re-writing a SOC at an existing `(owner, identifier)` is undefined and discouraged. Applications that need mutability MUST use distinct identifiers (e.g. the feed pattern `keccak256(topic || index)`), and applications that need overwrite-rejection MUST use `swarm_writeFeedEntry`.
+
+---
+
+#### `swarm_readSingleOwnerChunk`
+
+Retrieve a Single Owner Chunk. Read-only operation on public Swarm data; requires NO permission grant. Subject to the per-origin rate limits described in [Security Considerations](#resource-exhaustion).
+
+**Params:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `address` | `string` | Conditional | 64-character hex SOC address. |
+| `owner` | `string` | Conditional | Ethereum address of the SOC owner. Required if `address` is not provided. |
+| `identifier` | `string` | Conditional | 64-character hex identifier. Required if `address` is not provided. |
+| `options` | `object` | No | Reserved for future use. Unknown fields MUST be rejected with `unsupported_option`. |
+
+Exactly one of `address`, or the pair (`owner` + `identifier`), MUST be provided. When the pair is given, the provider derives the address as `keccak256(identifier_32 || owner_20)`.
+
+**Result:**
+
+```javascript
+{
+  data: string,            // Base64-encoded payload (span field stripped)
+  encoding: "base64",
+  span: number | bigint,   // Decoded span value; `number` when ≤ Number.MAX_SAFE_INTEGER, `bigint` otherwise
+  reference: string,       // 64-character hex SOC address (echoed/derived)
+  owner: string,       // Recovered owner address
+  identifier: string,
+  signature: string    // 130-character hex (65-byte) SOC signature, for caller-side verification
+}
+```
+
+**Errors:** `4900` if node unreachable, `-32602` if params invalid (`invalid_owner`, `invalid_identifier`, `invalid_reference`, `unsupported_option`). `data.reason` is `chunk_not_found` if no SOC exists at the address, `chunk_type_mismatch` if the returned bytes do not validate as a SOC for the requested address, or `rate_limited` if the per-origin budget is exceeded.
+
+**Behavior:**
+- Exact-match by address — no heuristics, no at-or-before search.
+- Implementations MUST parse the returned SOC, recover the signer from the signature, derive `keccak256(identifier_32 || owner_20)`, and reject any chunk whose derived address does not equal the requested address (`chunk_type_mismatch`). A returned CAC at the same address MUST be rejected here.
+- Node-mode independent; consumes no stamps; pre-flight limited to HTTP reachability. Transient vs. not-found distinction as in `swarm_readChunk`.
+
+---
+
+#### `swarm_getSigningIdentity`
+
+Return the origin's signing identity — the key the provider uses to sign feed updates and SOCs on this origin's behalf. Useful for pre-computing SOC addresses (e.g. for epoch-feed construction) before any write, and as the canonical entry point for acquiring the feed-permission grant without committing to a specific write.
+
+This method operates under the **feed permission tier**: the returned address *is* the dApp's persistent on-chain identity, and exposing it without consent would let arbitrary pages enumerate per-origin identities.
+
+**Params:** None.
+
+**Result:**
+
+```javascript
+{
+  owner: string,        // Checksummed Ethereum address of the signing key
+  identityMode: string  // "app-scoped" or "bee-wallet" (whichever was established at feed-permission grant)
+}
+```
+
+**Errors:** `4001` if the user rejects the feed-permission prompt. `4100` if the origin has not been granted basic connection (`swarm_requestAccess`) or the implementation cannot surface a permission prompt in the current context (e.g. a nested browsing context where consent UI is unavailable).
+
+**Behavior:**
+- If the calling origin has not yet been granted the feed-permission tier, the implementation MUST prompt the user for feed/signing access (the same prompt as `swarm_createFeed`'s first call) and return the identity on approval. This makes `swarm_getSigningIdentity` a viable bootstrap path for dApps that need to pre-compute SOC addresses before any write.
+- If feed-permission has already been granted, the method MUST return immediately without prompting.
+- The returned `owner` MUST be identical to the `owner` returned by `swarm_createFeed`, `swarm_writeSingleOwnerChunk`, and the entries of `swarm_listFeeds` for this origin.
+- The identity is stable for the lifetime of the origin's feed-permission grant. Identity mode selection happens once, at feed-permission grant time; there is no caller-driven mode selection in v1 (see [Future Extensions](#future-extensions)).
 
 ---
 
@@ -597,14 +792,14 @@ The key insight: the origin is derived from the **user-visible URL** (the addres
 #### Permission Lifecycle
 
 1. **Connection:** Granted via `swarm_requestAccess`. Persisted per-origin.
-2. **Publish:** Each `swarm_publishData`/`swarm_publishFiles` call MAY require per-operation user approval, unless the user has opted into auto-approve for this origin.
-3. **Feed writes:** Feed write operations (`swarm_createFeed`, `swarm_updateFeed`, `swarm_writeFeedEntry`) require an additional feed-specific permission grant, separate from the connection permission.
-4. **Feed reads and introspection:** `swarm_readFeedEntry` and `swarm_listFeeds` require NO permission grant. Swarm feeds are public data, and per-origin feed metadata is deterministic given `(origin, name)` — neither operation reveals anything the caller couldn't obtain elsewhere or compute itself. Both methods MUST work without a prior `swarm_requestAccess`.
-5. **Disconnection:** The user can revoke access at any time. The provider MUST emit a `disconnect` event and reject subsequent permission-gated requests with error code `4100`. Permission-free read methods (`swarm_getCapabilities`, `swarm_readFeedEntry`, `swarm_listFeeds`) MUST continue to function after disconnection — `swarm_listFeeds` in particular continues returning the previously-created feed records, which by design persist across revocation so a subsequent re-grant restores identity continuity.
+2. **Publish:** Each `swarm_publishData`/`swarm_publishFiles`/`swarm_publishChunk` call MAY require per-operation user approval, unless the user has opted into auto-approve for this origin. CAC chunk uploads fall under the same publish tier as `swarm_publishData`. If a per-publish prompt is shown and the user rejects it, the method MUST reject with `4001` (User Rejected); `4100` (Unauthorized) remains reserved for the cases where the origin lacks basic connection or the implementation cannot surface a permission prompt in the current context.
+3. **Feed writes and signing:** Operations that involve signing with the origin's identity — `swarm_createFeed`, `swarm_updateFeed`, `swarm_writeFeedEntry`, `swarm_writeSingleOwnerChunk`, and the identity-disclosure method `swarm_getSigningIdentity` — require an additional feed-specific permission grant, separate from the connection permission. Raw SOC writes are gated here (not under the publish tier) because they involve signing and share key material with feeds. Any feed-tier method MAY trigger a user prompt to acquire this grant on first call. If the user rejects, the method MUST reject with `4001` (User Rejected); `4100` (Unauthorized) is reserved for the cases where the origin lacks basic connection or the implementation cannot surface a permission prompt in the current context.
+4. **Reads and introspection:** `swarm_readFeedEntry`, `swarm_readChunk`, `swarm_readSingleOwnerChunk`, and `swarm_listFeeds` require NO permission grant. The data is either public on Swarm or deterministic given the caller's origin — none of it reveals anything the caller couldn't obtain elsewhere or compute itself. All four methods MUST work without a prior `swarm_requestAccess`, and MUST be rate-limited per origin (see [Security Considerations](#resource-exhaustion)).
+5. **Disconnection:** The user can revoke access at any time. The provider MUST emit a `disconnect` event and reject subsequent permission-gated requests with error code `4100`. Permission-free methods (`swarm_getCapabilities`, `swarm_readFeedEntry`, `swarm_readChunk`, `swarm_readSingleOwnerChunk`, `swarm_listFeeds`) MUST continue to function after disconnection — `swarm_listFeeds` in particular continues returning the previously-created feed records, which by design persist across revocation so a subsequent re-grant restores identity continuity.
 
 #### Auto-Approve (OPTIONAL)
 
-Implementations MAY offer users the option to auto-approve publish and/or feed operations for trusted origins. When auto-approve is active:
+Implementations MAY offer users the option to auto-approve publish (including CAC chunk uploads) and/or feed operations (including SOC writes) for trusted origins. When auto-approve is active:
 - The implementation MUST still enforce all validation, size limits, and pre-flight checks.
 - The implementation SHOULD provide a visual indicator that auto-approve is active.
 - The user MUST be able to revoke auto-approve at any time.
@@ -621,6 +816,7 @@ Implementations MUST enforce upload size, file count, and path length limits. Th
 | `maxFilesBytes` | 50 MB (52,428,800 bytes) | Total size across all entries in `swarm_publishFiles`. |
 | `maxFileCount` | 100 files | Per `swarm_publishFiles` call. |
 | `maxPathBytes` | 100 (UTF-8 bytes) | Per `files[].path` in `swarm_publishFiles`. Implementations MUST advertise at least 100. |
+| `maxChunkPayloadBytes` | 4096 (bytes) | Per `swarm_publishChunk` and `swarm_writeSingleOwnerChunk` payload. Fixed by the Swarm chunk protocol; implementations MUST advertise exactly 4096. |
 
 Implementations MAY use different limits but MUST report them accurately in `swarm_getCapabilities`.
 
@@ -658,9 +854,29 @@ Many applications also need an **append-only log**: user activity feeds, message
 
 `swarm_writeFeedEntry` and `swarm_readFeedEntry` expose the native Swarm feed index, enabling O(1) appends (write one SOC, no reads) and O(N) parallel reconstruction (fetch individual entries by index). The overwrite protection on explicit indices ensures the core safety guarantee: no silent history corruption.
 
-### Why do feed reads not require feed permission?
+### Why do feed and chunk reads require no permission grant?
 
-Swarm feeds are public data — anyone who knows the owner address and topic can read any feed entry on the network. The connection permission gate (`swarm_requestAccess`) ensures the origin has been approved to route requests through the user's Bee node. Adding a per-feed read ACL would be security theater: the same data is accessible via any other Bee node or gateway. Keeping reads lightweight (connection-only, no vault unlock, no stamps check) enables use cases like profile pages and cross-user activity views without unnecessary permission prompts.
+Swarm feeds, CACs, and SOCs are public data — anyone who knows the address (or owner + identifier, or owner + topic + index) can read any chunk on the network from any Bee gateway. Adding a per-origin ACL on top would be security theater: gating doesn't restrict access to the data, only routes around the user's node, which any page can do on its own.
+
+What gating *would* restrict is the user's bandwidth, local cache, and connection. Those are the real resources at risk, and they are protected by the **mandatory per-origin rate and bandwidth limits** specified in [Resource Exhaustion](#resource-exhaustion) — including tighter budgets for origins that have never called `swarm_requestAccess`. This puts the control where the actual risk lives, instead of behind a permission prompt that would block legitimate use cases (profile pages, cross-user activity views, link previews) for no security gain.
+
+The same logic extends to `swarm_listFeeds`: feed coordinates are deterministic given `(origin, name)`, so listing them reveals nothing the calling origin could not compute itself.
+
+### Why expose chunk operations?
+
+Every Swarm data structure — feeds, manifests, ACT, GSOC, future constructions not yet supported by Bee such as epoch feeds — is built from chunks. Without a chunk tier, every new high-level primitive Swarm gains would require a new method in this specification and a new revision to ship it.
+
+Exposing CAC and SOC read/write at the provider boundary moves that experimentation into the library layer: a library author can build a new manifest format, a new feed scheme, or a new access-control overlay on top of `swarm_publishChunk`/`swarm_readChunk`/`swarm_writeSingleOwnerChunk`/`swarm_readSingleOwnerChunk`, without touching this specification. This mirrors EIP-1193's role on Ethereum, where `eth_sendRawTransaction` and friends are the low-level transport and ergonomic abstractions (ethers, viem) live as libraries.
+
+The chunk tier is constrained the same way the high-level methods are: origin-scoped permissions, host-managed postage, fixed payload size limit, per-origin rate budgets on permission-free reads, and signing-key custody inside the trusted context. It adds expressiveness without weakening the security posture — a 4 KB opaque blob upload is strictly less powerful than a 10 MB `swarm_publishData` call the same origin can already make.
+
+### Why type-explicit method names?
+
+Swarm chunks carry no in-band type tag, and a chunk's address does not encode whether the chunk is a CAC or a SOC. Bee disambiguates heuristically, which has produced real edge cases (see [SWIP-67](https://github.com/ethersphere/SWIPs/pull/67), [bee#5445](https://github.com/ethersphere/bee/pull/5445)).
+
+Rather than wait on a Bee-level resolution or introduce our own heuristics, the API encodes the type in the method name: `swarm_publishChunk`/`swarm_readChunk` for CACs, `swarm_writeSingleOwnerChunk`/`swarm_readSingleOwnerChunk` for SOCs. The caller declares intent, the provider applies the correct upload endpoint and verification rules, and the spec does not depend on the upstream ambiguity ever being resolved.
+
+This also unblocks a clean validation contract: on every read, the provider recomputes the type-specific address from the returned bytes and rejects mismatches as `chunk_type_mismatch`. The caller can rely on "if `swarm_readChunk(addr)` returned bytes, those bytes are the CAC at `addr`" — a guarantee the underlying Bee endpoint does not give.
 
 ### Why base64 for read responses?
 
@@ -686,7 +902,17 @@ A connected origin could repeatedly publish data up to the size limit, consuming
 - **Stamp monitoring:** Warning the user when stamp capacity is running low due to dApp activity.
 - **Per-origin accounting:** Tracking cumulative usage per origin so users can identify heavy consumers.
 
-This specification does not mandate a specific rate-limiting scheme, as appropriate limits depend on the node's capacity and the user's preferences.
+This specification does not mandate a specific rate-limiting scheme for permissioned operations, as appropriate limits depend on the node's capacity and the user's preferences.
+
+#### Permission-Free Reads
+
+The read methods that require no permission grant — `swarm_readFeedEntry`, `swarm_readChunk`, `swarm_readSingleOwnerChunk`, and `swarm_listFeeds` — can be invoked by any page that loads the provider, including pages the user has never granted access to. `swarm_readChunk` in particular widens this to arbitrary chunk addresses, effectively turning the user's node into a public retrieval path on behalf of any page.
+
+The capability itself is benign — the same data is available from any public Swarm gateway — but the user's bandwidth, local cache, and network connection are not. Without throttling, a hostile page could drain the user's bandwidth by issuing high-volume chunk reads, or probe the local cache via timing.
+
+Implementations MUST enforce **per-origin rate and bandwidth limits** on permission-free read methods. Origins exceeding the configured budget MUST receive `-32602` with `data.reason = "rate_limited"` (an analytics-friendly reason code, not an error condition the dApp should retry without backoff). Implementations MAY apply tighter limits to origins that have never called `swarm_requestAccess` than to previously-connected origins.
+
+This specification does not mandate specific numeric thresholds, as appropriate limits depend on the node's bandwidth and the user's preferences. Implementations SHOULD make the limits user-visible and adjustable.
 
 ### Iframe and Nested Context Behavior
 
@@ -709,8 +935,15 @@ Implementations that create temporary files or directories during upload process
 The following capabilities are anticipated for future versions of this specification and are explicitly out of scope for version 1.0:
 
 - **`capabilitiesChanged` event** — Proactive notification when the provider's capabilities change (e.g., node goes offline, stamps exhausted). Currently dApps must poll `swarm_getCapabilities` to detect state changes.
-- **`preferredIdentityMode` parameter for `swarm_createFeed`** — Allow dApps to express a preference for `app-scoped` or `bee-wallet` identity mode, rather than relying solely on user/implementation choice.
-- **`encoding` parameter for `swarm_readFeedEntry`** — Allow callers to request a specific response encoding (e.g., `"utf8"`) to avoid manual base64 decoding for text payloads.
+- **`preferredIdentityMode` parameter** — Allow dApps to express a preference for `app-scoped` or `bee-wallet` identity mode, rather than relying solely on user/implementation choice. When added, this parameter SHOULD land on `swarm_createFeed`, `swarm_writeSingleOwnerChunk`, and `swarm_getSigningIdentity` consistently.
+- **`encoding` parameter for `swarm_readFeedEntry`, `swarm_readChunk`, `swarm_readSingleOwnerChunk`** — Allow callers to request a specific response encoding (e.g., `"utf8"`) to avoid manual base64 decoding for text payloads.
+- **Expanded chunk `options`** — The chunk methods' `options` object is intentionally empty in v1, with `unsupported_option` providing forward-compat enforcement. Candidate fields for future revisions, each requiring a precise mapping to Bee's endpoint contract before standardization:
+  - `trackProgress: true` on writes — provider issues a fresh origin-scoped `tagUid` (returned in the result) usable with `swarm_getUploadStatus`. The page MUST NOT supply a `tag` value directly, to preserve the origin ownership invariant `swarm_getUploadStatus` enforces.
+  - `cache: boolean` on reads — pass-through to Bee's cache header.
+  - **ACT (Access Control Trie)** on reads — Bee's `/chunks` endpoint accepts ACT headers; once ACT semantics are specified at this layer (key custody, grantee management, history references), it is a natural fit for the chunk tier.
+  - **Per-chunk encryption** — Bee's encryption primitive currently lives at the `/bytes` BMT-tree layer, not at single `/chunks`. Adding it at the chunk tier requires either a Bee-level addition or a client-side convention; both are out of scope for v1.
+  - **Redundancy (erasure coding)** — Same situation as encryption: a BMT-tree-layer feature in Bee, not a single-chunk one.
+  - **`deferred` upload** — Bee's `swarm-deferred-upload` header is endpoint-general but not guaranteed at `/chunks`; pending verification.
 
 Additionally, the `specVersion` field in `swarm_getCapabilities` is currently a SHOULD. A future revision may promote it to MUST once multiple implementations exist and version negotiation becomes necessary.
 
@@ -810,7 +1043,9 @@ try {
 ### Post-Disconnect Behavior
 
 ```javascript
-// After user revokes access, all methods reject with 4100
+// After user revokes access, permission-gated methods reject with 4100.
+// Permission-free methods (getCapabilities, readFeedEntry, readChunk,
+// readSingleOwnerChunk, listFeeds) MUST continue to function.
 // (simulate disconnect via browser UI, then:)
 try {
   await window.swarm.publishData({ data: 'test', contentType: 'text/plain' });
@@ -818,6 +1053,14 @@ try {
 } catch (err) {
   assert(err.code === 4100); // Unauthorized
 }
+
+// Permission-free introspection still works:
+const feeds = await window.swarm.listFeeds();
+assert(Array.isArray(feeds)); // Returns previously-created feed records
+
+const caps = await window.swarm.getCapabilities();
+assert(caps.canPublish === false);
+assert(caps.reason === 'not-connected');
 ```
 
 ### Feed Idempotency
@@ -1004,7 +1247,7 @@ if (caps.specVersion) assert(typeof caps.specVersion === 'string');
 
 ## Implementation
 
-A reference implementation exists in [Freedom Browser](https://github.com/solardev-xyz/freedom-browser) (PR [#19](https://github.com/solardev-xyz/freedom-browser/pull/19)):
+[Freedom Browser](https://github.com/solardev-xyz/freedom-browser) (PR [#19](https://github.com/solardev-xyz/freedom-browser/pull/19)) implements the original high-level surface — `swarm_requestAccess`, `swarm_getCapabilities`, `swarm_publishData`, `swarm_publishFiles`, `swarm_getUploadStatus`, `swarm_createFeed`, `swarm_updateFeed`, `swarm_writeFeedEntry`, `swarm_readFeedEntry`, `swarm_listFeeds`:
 
 - **Provider injection:** [`src/main/webview-preload.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing-updated/src/main/webview-preload.js) — `window.swarm` object injected into webview page context
 - **Main-process enforcement:** [`src/main/swarm/swarm-provider-ipc.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing-updated/src/main/swarm/swarm-provider-ipc.js) — method dispatch, validation, origin enforcement
@@ -1013,7 +1256,9 @@ A reference implementation exists in [Freedom Browser](https://github.com/solard
 - **Permissions:** [`src/main/swarm/swarm-permissions.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing-updated/src/main/swarm/swarm-permissions.js) — origin-scoped permission store
 - **Origin normalization:** [`src/shared/origin-utils.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing-updated/src/shared/origin-utils.js) — dweb-aware origin extraction
 
-A reference dApp consuming this API exists in [Swarmit](https://github.com/flotob/swarmit), a decentralized message board that uses `swarm_requestAccess`, `swarm_publishData`, `swarm_createFeed`, `swarm_writeFeedEntry`, `swarm_readFeedEntry`, and `swarm_listFeeds` for its full publishing and profile-discovery pipeline.
+[Swarmit](https://github.com/flotob/swarmit) — a decentralized message board — exercises the core publish/feed flows from a consuming dApp, using `swarm_requestAccess`, `swarm_publishData`, `swarm_createFeed`, `swarm_writeFeedEntry`, `swarm_readFeedEntry`, and `swarm_listFeeds`.
+
+The low-level chunk tier (`swarm_publishChunk`, `swarm_readChunk`, `swarm_writeSingleOwnerChunk`, `swarm_readSingleOwnerChunk`), `swarm_getSigningIdentity`, the chunk-type validation contract, and the MUST-level per-origin rate limiting on permission-free reads are newly proposed in this draft from review feedback and are not yet implemented on either side. Reference implementations will follow in a subsequent Freedom Browser PR.
 
 ## Copyright
 

--- a/SWIPs/swip-draft_provider_api.md
+++ b/SWIPs/swip-draft_provider_api.md
@@ -185,9 +185,10 @@ Returns the current capabilities of the provider for this origin. Does NOT requi
   canPublish: boolean,     // true if connected AND node is ready
   reason: string | null,   // null if canPublish is true, otherwise a reason code
   limits: {
-    maxDataBytes: number,  // Maximum payload size for swarm_publishData
+    maxDataBytes: number,  // Maximum payload size for swarm_publishData and swarm_writeFeedEntry
     maxFilesBytes: number, // Maximum total size for swarm_publishFiles
-    maxFileCount: number   // Maximum number of files per swarm_publishFiles call
+    maxFileCount: number,  // Maximum number of files per swarm_publishFiles call
+    maxPathBytes: number   // Maximum length of a file path in swarm_publishFiles, measured in UTF-8 bytes
   }
 }
 ```
@@ -258,7 +259,7 @@ Upload a collection of files as a Swarm manifest (directory).
 | `contentType` | `string` | No | MIME type. Implementation MAY infer from path if omitted. |
 
 **Path validation rules:**
-- Must be a non-empty string, maximum 256 characters.
+- Must be a non-empty string. Maximum length is `maxPathBytes` UTF-8 bytes, advertised via `swarm_getCapabilities`. Length MUST be measured in UTF-8 bytes, not Unicode characters or UTF-16 code units — a single emoji is 4 bytes, not 1.
 - No backslashes, no leading slash, no empty segments, no `.` or `..` segments.
 - No control characters (code points < 32).
 - Paths must be unique within the `files` array.
@@ -390,7 +391,9 @@ Update a feed to point at a new content reference.
 
 Write an arbitrary payload directly to a feed index as a Single Owner Chunk (SOC).
 
-This enables the **journal pattern** — an append-only log where each entry is an independently-addressed chunk at an incrementing index. Unlike `swarm_updateFeed` (which stores a 32-byte content reference), `swarm_writeFeedEntry` stores the payload directly in the SOC. For payloads larger than the 4 KB SOC limit, the underlying implementation uploads the data separately and wraps the root chunk into the SOC transparently.
+This enables the **journal pattern** — an append-only log where each entry is an independently-addressed chunk at an incrementing index. Unlike `swarm_updateFeed` (which stores a 32-byte content reference), `swarm_writeFeedEntry` stores the payload in the feed itself.
+
+The 4 KB SOC body limit is internal to the storage envelope and is NOT a dApp-visible payload cap. Payloads up to the SOC limit are stored directly in the chunk; larger payloads MUST be wrapped transparently — the implementation uploads the bytes (e.g., as a BMT tree via `POST /bytes`) and writes only the root chunk reference into the SOC body. DApps see one consistent payload cap, `maxDataBytes`, across `swarm_publishData` and `swarm_writeFeedEntry`.
 
 **Params:**
 
@@ -408,13 +411,14 @@ This enables the **journal pattern** — an append-only log where each entry is 
 }
 ```
 
-**Errors:** `4100` if not connected or feed access not granted, `4900` if node unavailable, `-32602` if params invalid, feed doesn't exist, index is occupied (`index_already_exists`), or payload exceeds SOC size limit (`payload_too_large`).
+**Errors:** `4100` if not connected or feed access not granted, `4900` if node unavailable, `-32602` if params invalid, feed doesn't exist, index is occupied (`index_already_exists`), or payload exceeds `maxDataBytes` (`payload_too_large`).
 
 **Behavior:**
 
 - The feed MUST already exist (created via `swarm_createFeed`).
 - If `index` is omitted, the provider MUST resolve the next available index and write at that index. The resolved index is returned.
-- If `index` is provided, the provider MUST check whether an entry already exists at that index. If it does, the write MUST be rejected with error data `{ reason: "index_already_exists" }`. This overwrite protection is the core safety guarantee of the journal pattern.
+- If `index` is provided, the provider MUST check whether an entry already exists at that exact index. If it does, the write MUST be rejected with error data `{ reason: "index_already_exists" }`. This overwrite protection is the core safety guarantee of the journal pattern.
+- The existence check MUST use **exact-match** semantics — see [Implementation Note: Exact-Match Feed Reads](#implementation-note-exact-match-feed-reads). Implementations MUST NOT use Bee's `GET /feeds/{owner}/{topic}?index=N` endpoint for this probe: that endpoint has at-or-before semantics and would falsely reject any sparse-index write whenever any earlier index exists.
 - The overwrite check and the write MUST be atomic — implementations MUST NOT allow concurrent writes to race between the check and the write to the same index. A per-topic serialization mechanism (e.g., a mutex) is RECOMMENDED.
 - Sparse indices are valid. Writing to index 1000 without indices 0–999 existing is allowed. Applications that want sequential journal semantics SHOULD omit `index` and rely on auto-increment.
 
@@ -478,6 +482,7 @@ Structured error reasons in `data.reason`:
 - Pre-flight checks MUST be limited to verifying the Bee node's HTTP API is reachable. Mode checks (ultra-light), readiness checks, and stamp checks MUST NOT be applied — reads work regardless of node mode and do not consume stamps.
 - Implementations MUST distinguish "not found" errors (HTTP 404/500 from the Bee API) from transient errors (network timeouts, internal failures). Transient errors MUST propagate as `-32603` (Internal Error), NOT be misclassified as `feed_empty` or `entry_not_found`.
 - When reading the latest entry (`index` omitted), `nextIndex` indicates the next index available for writing. When reading a specific index, `nextIndex` is `null`.
+- When `index` is provided, implementations MUST use **exact-match** semantics — see [Implementation Note: Exact-Match Feed Reads](#implementation-note-exact-match-feed-reads). The returned `result.index` MUST equal the requested `index`. Implementations MUST NOT return data from a different index that happens to be the highest at-or-before the requested index.
 
 ---
 
@@ -523,6 +528,52 @@ Returns an empty array `[]` for origins with no feeds — including origins that
 
 ---
 
+### Implementation Note: Exact-Match Feed Reads
+
+This section is **informative**. It documents a Bee API behavior that affects the correctness of `swarm_writeFeedEntry`'s overwrite protection and `swarm_readFeedEntry`'s explicit-index path.
+
+#### The problem
+
+Bee's `GET /feeds/{owner}/{topic}?index=N` endpoint does NOT return the entry at exact index N. Its semantics are **at-or-before**: the endpoint performs an epoch search and returns the latest Single Owner Chunk (SOC) at index ≤ N. So:
+
+- A read of index 6 on a feed where only index 3 has been written returns index 3's chunk (with no out-of-band signal that index 6 itself is empty).
+- A pre-write existence probe at index 6 returns whatever's at index 5 / 4 / ... / 0 if any of them exist, falsely flagging index 6 as occupied.
+
+For the journal pattern, this breaks both halves of the contract: explicit-index reads can return the wrong entry, and overwrite protection falsely rejects sparse writes.
+
+#### The fix
+
+Implementations SHOULD derive the SOC address directly and fetch via `GET /chunks/{socAddress}`, which is exact-match.
+
+```
+identifier  = keccak256( topic_32 || index_8BE )
+socAddress  = keccak256( identifier_32 || ownerAddress_20 )
+```
+
+Where:
+- `topic_32` — the feed's 32-byte topic (the same topic used elsewhere in the feed API).
+- `index_8BE` — the feed index encoded as **8 bytes big-endian**.
+- `ownerAddress_20` — the 20-byte Ethereum address of the feed signer.
+
+A 404 from `GET /chunks/{socAddress}` means no entry exists at the exact requested index — translated to `entry_not_found` for reads and "index available" for pre-write probes. 5xx and connection errors MUST propagate as transient (`-32603` Internal Error), NOT be misclassified as not-found.
+
+#### When to use which endpoint
+
+The latest-entry read path is unaffected — at-or-before is exactly the desired behavior, and `GET /feeds/{owner}/{topic}` returns the latest entry plus the `swarm-feed-index` and `swarm-feed-index-next` response headers (`%016x`) that drive auto-increment.
+
+| Operation | Endpoint | Semantics |
+|---|---|---|
+| `swarm_readFeedEntry` (no `index`) — latest entry + `nextIndex` | `GET /feeds/{owner}/{topic}` | At-or-before |
+| `swarm_writeFeedEntry` auto-increment — find next writable index | `GET /feeds/{owner}/{topic}` | At-or-before |
+| `swarm_readFeedEntry` with explicit `index` | `GET /chunks/{socAddress}` | Exact-match |
+| `swarm_writeFeedEntry` overwrite probe | `GET /chunks/{socAddress}` | Exact-match |
+
+#### Endianness trap
+
+Bee uses **big-endian** for the 8-byte feed index in identifier derivation, but **little-endian** for the 8-byte `span` (payload length) prefix in the SOC body. These are different fields with different conventions in the same operation. Implementations going through `bee-js` get both right via its built-in helpers; implementations writing directly against this spec MUST handle the two conventions separately.
+
+---
+
 ### Permission Model
 
 #### Origin Normalization
@@ -562,15 +613,18 @@ Implementations MAY offer users the option to auto-approve publish and/or feed o
 
 ### Limits
 
-Implementations MUST enforce upload size and file count limits. The limits MUST be discoverable via `swarm_getCapabilities`. Recommended defaults:
+Implementations MUST enforce upload size, file count, and path length limits. The limits MUST be discoverable via `swarm_getCapabilities`. Recommended defaults:
 
-| Limit | Recommended Default |
-|---|---|
-| `maxDataBytes` | 10 MB (10,485,760 bytes) |
-| `maxFilesBytes` | 50 MB (52,428,800 bytes) |
-| `maxFileCount` | 100 files |
+| Limit | Recommended Default | Notes |
+|---|---|---|
+| `maxDataBytes` | 10 MB (10,485,760 bytes) | Applies to both `swarm_publishData` and `swarm_writeFeedEntry` payloads. |
+| `maxFilesBytes` | 50 MB (52,428,800 bytes) | Total size across all entries in `swarm_publishFiles`. |
+| `maxFileCount` | 100 files | Per `swarm_publishFiles` call. |
+| `maxPathBytes` | 100 (UTF-8 bytes) | Per `files[].path` in `swarm_publishFiles`. Implementations MUST advertise at least 100. |
 
 Implementations MAY use different limits but MUST report them accurately in `swarm_getCapabilities`.
+
+The `maxPathBytes` floor of 100 reflects current implementation reality: reference implementations build uploads as USTAR tar archives (`Content-Type: application/x-tar` with `Swarm-Collection: true`), and USTAR's `name` header field is exactly 100 bytes. Without PAX extensions — which are out of scope for v1 — paths longer than 100 UTF-8 bytes cannot be encoded. Future implementations supporting PAX or alternative upload formats MAY advertise a larger `maxPathBytes`.
 
 ---
 
@@ -835,6 +889,26 @@ try {
 }
 ```
 
+### Feed Journal — Sparse-Index Writes (Exact-Match Requirement)
+
+```javascript
+// Sparse writes are valid: writing index 5 with no entries 1-4 must succeed.
+// Implementations using at-or-before semantics for the overwrite probe would
+// falsely reject this write because index 0 exists.
+await window.swarm.createFeed({ name: 'sparse' });
+await window.swarm.writeFeedEntry({ name: 'sparse', data: 'first', index: 0 });
+const w5 = await window.swarm.writeFeedEntry({ name: 'sparse', data: 'fifth', index: 5 });
+assert(w5.index === 5);
+
+// Reading explicit index 5 must return index 5's data, not index 0's.
+// Implementations using at-or-before semantics for explicit-index reads would
+// silently return index 0's payload.
+const r5 = await window.swarm.readFeedEntry({ name: 'sparse', index: 5 });
+assert(r5.index === 5);
+const bytes = Uint8Array.from(atob(r5.data), c => c.charCodeAt(0));
+assert(new TextDecoder().decode(bytes) === 'fifth');
+```
+
 ### Feed Journal — Cross-User Read
 
 ```javascript
@@ -922,6 +996,8 @@ const caps = await window.swarm.getCapabilities();
 assert(caps.canPublish === false);
 assert(caps.reason === 'not-connected');
 assert(typeof caps.limits.maxDataBytes === 'number');
+assert(typeof caps.limits.maxPathBytes === 'number');
+assert(caps.limits.maxPathBytes >= 100);
 // specVersion is optional (SHOULD) in 1.0
 if (caps.specVersion) assert(typeof caps.specVersion === 'string');
 ```

--- a/SWIPs/swip-draft_provider_api.md
+++ b/SWIPs/swip-draft_provider_api.md
@@ -11,11 +11,11 @@ created: 2026-04-03
 
 ## Simple Summary
 
-A standard JavaScript API (`window.swarm`) that enables web pages to request access to a user's Swarm node for publishing data, uploading files, managing mutable feeds, and reading/writing indexed feed entries — with user consent and origin-scoped permissions.
+A standard JavaScript API (`window.swarm`) that enables web pages to request access to a user's Swarm node for publishing data, uploading files, managing mutable feeds, reading/writing indexed feed entries, and introspecting their own feed records — with user consent and origin-scoped permissions.
 
 ## Abstract
 
-This SWIP defines a browser-injected JavaScript provider object (`window.swarm`) that allows web applications to interact with a user's local Swarm (Bee) node. The API follows the request/response pattern established by [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) for Ethereum providers, adapted for Swarm's publishing and feed primitives. It specifies nine RPC methods covering connection, capability discovery, data/file publishing, upload tracking, mutable feed management, and indexed feed entry read/write. The provider includes a permission model with explicit user consent, origin isolation, and upload size limits.
+This SWIP defines a browser-injected JavaScript provider object (`window.swarm`) that allows web applications to interact with a user's local Swarm (Bee) node. The API follows the request/response pattern established by [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) for Ethereum providers, adapted for Swarm's publishing and feed primitives. It specifies ten RPC methods covering connection, capability discovery, data/file publishing, upload tracking, mutable feed management, indexed feed entry read/write, and origin-scoped feed introspection. The provider includes a permission model with explicit user consent, origin isolation, and upload size limits. Read-only methods that operate on public Swarm data — including feed entry reads and the calling origin's own feed introspection — do not require a connection grant.
 
 ## Motivation
 
@@ -82,6 +82,7 @@ window.swarm.createFeed({ name })                 // swarm_createFeed
 window.swarm.updateFeed({ feedId, reference })    // swarm_updateFeed
 window.swarm.writeFeedEntry({ name, data })       // swarm_writeFeedEntry
 window.swarm.readFeedEntry({ name, owner })       // swarm_readFeedEntry
+window.swarm.listFeeds()                          // swarm_listFeeds
 ```
 
 Each convenience method MUST be equivalent to calling `window.swarm.request()` with the corresponding method name and parameters.
@@ -423,7 +424,7 @@ This enables the **journal pattern** — an append-only log where each entry is 
 
 #### `swarm_readFeedEntry`
 
-Read a feed entry at a specific index, or read the latest entry. This is a read-only operation that does NOT require feed-level permission — only a basic connection (`swarm_requestAccess`).
+Read a feed entry at a specific index, or read the latest entry. This is a read-only operation on public Swarm data and does NOT require any permission grant — neither connection (`swarm_requestAccess`) nor feed-level. Any web page MAY call it.
 
 **Params:**
 
@@ -461,7 +462,7 @@ const bytes = Uint8Array.from(atob(result.data), c => c.charCodeAt(0))
 const text = new TextDecoder().decode(bytes)
 ```
 
-**Errors:** `4100` if not connected, `4900` if node unreachable, `-32602` if params invalid.
+**Errors:** `4900` if node unreachable, `-32602` if params invalid. Notably does NOT return `4100` — no permission is required to call this method.
 
 Structured error reasons in `data.reason`:
 
@@ -473,10 +474,52 @@ Structured error reasons in `data.reason`:
 
 **Behavior:**
 
-- This method does NOT require feed-level permission — only connection permission (`swarm_requestAccess`). Feeds are public data on Swarm; the connection gate ensures the origin has been approved to use the user's Bee node.
+- This method does NOT require any permission grant. Feeds are public data on Swarm and the same lookup is available from any Bee gateway without auth; gating it would be friction without security benefit. This is symmetric with `swarm_listFeeds`.
 - Pre-flight checks MUST be limited to verifying the Bee node's HTTP API is reachable. Mode checks (ultra-light), readiness checks, and stamp checks MUST NOT be applied — reads work regardless of node mode and do not consume stamps.
 - Implementations MUST distinguish "not found" errors (HTTP 404/500 from the Bee API) from transient errors (network timeouts, internal failures). Transient errors MUST propagate as `-32603` (Internal Error), NOT be misclassified as `feed_empty` or `entry_not_found`.
 - When reading the latest entry (`index` omitted), `nextIndex` indicates the next index available for writing. When reading a specific index, `nextIndex` is `null`.
+
+---
+
+#### `swarm_listFeeds`
+
+Return the calling origin's feed records — every feed previously created via `swarm_createFeed` under the caller's normalized origin.
+
+This is an introspection method scoped to the calling origin. It does NOT require any permission grant — neither connection (`swarm_requestAccess`) nor feed-level. Any web page MAY call it.
+
+**Params:** None. The result is determined entirely by the caller's normalized origin. Implementations SHOULD silently ignore any params supplied; strict rejection buys nothing for an introspection-only method.
+
+**Result:**
+
+```javascript
+[
+  {
+    name: string,                  // Feed name (as passed to swarm_createFeed)
+    topic: string,                 // 64-character hex topic (no 0x prefix)
+    owner: string,                 // Checksummed Ethereum address of the signing key
+    manifestReference: string,     // 64-character hex reference to the feed manifest
+    bzzUrl: string,                // "bzz://<manifestReference>"
+    createdAt: number,             // ms unix timestamp when createFeed was called
+    lastUpdated: number | null,    // ms unix timestamp of last swarm_updateFeed (null otherwise)
+    lastReference: string | null   // last reference written via swarm_updateFeed (null otherwise)
+  },
+  ...
+]
+```
+
+Returns an empty array `[]` for origins with no feeds — including origins that have never granted permission, origins that have granted but not created feeds, and origins whose permission has been revoked.
+
+**Errors:** None expected on the happy path. `-32603` (Internal Error) only on unexpected internal failures (e.g., feed-store read errors).
+
+**Behavior:**
+
+- **Origin scoping is mandatory.** The result MUST contain only feeds created under the calling page's normalized origin. Implementations MUST NOT return feeds created under any other origin.
+- **No permission required**, by design:
+  - Feed coordinates are deterministic given `(origin, name)` — the calling origin can compute the same set itself given the names of feeds it created. Listing them does not reveal anything beyond what the caller already knows.
+  - Feed metadata persists across permission revocation by design (so an origin re-granted access after revocation resumes its prior identity and can continue using its existing feeds). Requiring permission for introspection would create UX friction without security benefit.
+  - Symmetric with `swarm_readFeedEntry`: both are read-only operations on data the caller could obtain elsewhere.
+- **`lastUpdated` and `lastReference`** are populated only by `swarm_updateFeed`-style usage. For feeds maintained as journals via `swarm_writeFeedEntry`, both fields stay `null` (those operations do not update the manifest reference).
+- **`bzzUrl`** is a stable convenience built from `manifestReference`. For `swarm_updateFeed`-style feeds it resolves to the latest pointed-at content; for journal-style feeds (where the SOC payload is raw bytes rather than a content reference) the manifest URL has limited utility — applications should use `swarm_readFeedEntry` to read journal contents.
 
 ---
 
@@ -505,8 +548,8 @@ The key insight: the origin is derived from the **user-visible URL** (the addres
 1. **Connection:** Granted via `swarm_requestAccess`. Persisted per-origin.
 2. **Publish:** Each `swarm_publishData`/`swarm_publishFiles` call MAY require per-operation user approval, unless the user has opted into auto-approve for this origin.
 3. **Feed writes:** Feed write operations (`swarm_createFeed`, `swarm_updateFeed`, `swarm_writeFeedEntry`) require an additional feed-specific permission grant, separate from the connection permission.
-4. **Feed reads:** `swarm_readFeedEntry` requires only connection permission — no feed grant is needed. Swarm feeds are public data; any connected origin can read any feed if it knows the owner address and topic.
-5. **Disconnection:** The user can revoke access at any time. The provider MUST emit a `disconnect` event and reject subsequent requests with error code `4100`.
+4. **Feed reads and introspection:** `swarm_readFeedEntry` and `swarm_listFeeds` require NO permission grant. Swarm feeds are public data, and per-origin feed metadata is deterministic given `(origin, name)` — neither operation reveals anything the caller couldn't obtain elsewhere or compute itself. Both methods MUST work without a prior `swarm_requestAccess`.
+5. **Disconnection:** The user can revoke access at any time. The provider MUST emit a `disconnect` event and reject subsequent permission-gated requests with error code `4100`. Permission-free read methods (`swarm_getCapabilities`, `swarm_readFeedEntry`, `swarm_listFeeds`) MUST continue to function after disconnection — `swarm_listFeeds` in particular continues returning the previously-created feed records, which by design persist across revocation so a subsequent re-grant restores identity continuity.
 
 #### Auto-Approve (OPTIONAL)
 
@@ -611,7 +654,6 @@ Implementations that create temporary files or directories during upload process
 
 The following capabilities are anticipated for future versions of this specification and are explicitly out of scope for version 1.0:
 
-- **`swarm_listFeeds`** — Enumerate existing feeds for the calling origin. This would allow dApps to discover feeds without maintaining their own registry of feed names.
 - **`capabilitiesChanged` event** — Proactive notification when the provider's capabilities change (e.g., node goes offline, stamps exhausted). Currently dApps must poll `swarm_getCapabilities` to detect state changes.
 - **`preferredIdentityMode` parameter for `swarm_createFeed`** — Allow dApps to express a preference for `app-scoped` or `bee-wallet` identity mode, rather than relying solely on user/implementation choice.
 - **`encoding` parameter for `swarm_readFeedEntry`** — Allow callers to request a specific response encoding (e.g., `"utf8"`) to avoid manual base64 decoding for text payloads.
@@ -820,18 +862,46 @@ try {
 }
 ```
 
-### Feed Read Without Feed Grant
+### Feed Read Without Any Permission
 
 ```javascript
-// readFeedEntry requires only connection, not feed grant
-// (assuming connected but no feed permission granted)
+// readFeedEntry requires NO permission — no requestAccess, no feed grant.
+// An origin that has never called requestAccess can still read public feeds.
 const entry = await window.swarm.readFeedEntry({
   topic: 'a1b2c3...64-char-hex-topic...',
   owner: '0xSomeAddress',
   index: 0,
 });
-// Should succeed — feed grant not required for reads
 assert(typeof entry.data === 'string');
+assert(entry.encoding === 'base64');
+```
+
+### List Feeds — Origin-Scoped Introspection
+
+```javascript
+// Returns feeds previously created under the calling origin
+await window.swarm.createFeed({ name: 'user-feed' });
+await window.swarm.createFeed({ name: 'comments' });
+
+const feeds = await window.swarm.listFeeds();
+assert(Array.isArray(feeds));
+assert(feeds.length >= 2);
+
+const userFeed = feeds.find(f => f.name === 'user-feed');
+assert(userFeed.bzzUrl.startsWith('bzz://'));
+assert(/^[0-9a-f]{64}$/.test(userFeed.topic));
+assert(/^0x[0-9a-fA-F]{40}$/.test(userFeed.owner));
+assert(typeof userFeed.createdAt === 'number');
+```
+
+### List Feeds — Empty for Un-Granted Origin
+
+```javascript
+// listFeeds requires NO permission. An origin with no granted access
+// and no created feeds simply gets an empty array — never an error.
+const feeds = await window.swarm.listFeeds();
+assert(Array.isArray(feeds));
+assert(feeds.length === 0);
 ```
 
 ### Re-Connection Without Re-Prompt
@@ -866,9 +936,8 @@ A reference implementation exists in [Freedom Browser](https://github.com/solard
 - **Feeds:** [`src/main/swarm/feed-service.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing-updated/src/main/swarm/feed-service.js) — feed creation and updates
 - **Permissions:** [`src/main/swarm/swarm-permissions.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing-updated/src/main/swarm/swarm-permissions.js) — origin-scoped permission store
 - **Origin normalization:** [`src/shared/origin-utils.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing-updated/src/shared/origin-utils.js) — dweb-aware origin extraction
-- **Test page:** [`docs/swarm-provider-test/index.html`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing-updated/docs/swarm-provider-test/index.html) — interactive test harness
 
-A reference dApp consuming this API exists in [Swarmit](https://github.com/flotob/swarmit), a decentralized message board that uses `swarm_requestAccess`, `swarm_publishData`, `swarm_createFeed`, and `swarm_updateFeed` for its full publishing pipeline.
+A reference dApp consuming this API exists in [Swarmit](https://github.com/flotob/swarmit), a decentralized message board that uses `swarm_requestAccess`, `swarm_publishData`, `swarm_createFeed`, `swarm_writeFeedEntry`, `swarm_readFeedEntry`, and `swarm_listFeeds` for its full publishing and profile-discovery pipeline.
 
 ## Copyright
 

--- a/SWIPs/swip-draft_provider_api.md
+++ b/SWIPs/swip-draft_provider_api.md
@@ -11,11 +11,11 @@ created: 2026-04-03
 
 ## Simple Summary
 
-A standard JavaScript API (`window.swarm`) that enables web pages to request access to a user's Swarm node for publishing data, uploading files, and managing mutable feeds — with user consent and origin-scoped permissions.
+A standard JavaScript API (`window.swarm`) that enables web pages to request access to a user's Swarm node for publishing data, uploading files, managing mutable feeds, and reading/writing indexed feed entries — with user consent and origin-scoped permissions.
 
 ## Abstract
 
-This SWIP defines a browser-injected JavaScript provider object (`window.swarm`) that allows web applications to interact with a user's local Swarm (Bee) node. The API follows the request/response pattern established by [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) for Ethereum providers, adapted for Swarm's publishing and feed primitives. It specifies seven RPC methods covering connection, capability discovery, data/file publishing, upload tracking, and mutable feed management. The provider includes a permission model with explicit user consent, origin isolation, and upload size limits.
+This SWIP defines a browser-injected JavaScript provider object (`window.swarm`) that allows web applications to interact with a user's local Swarm (Bee) node. The API follows the request/response pattern established by [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) for Ethereum providers, adapted for Swarm's publishing and feed primitives. It specifies nine RPC methods covering connection, capability discovery, data/file publishing, upload tracking, mutable feed management, and indexed feed entry read/write. The provider includes a permission model with explicit user consent, origin isolation, and upload size limits.
 
 ## Motivation
 
@@ -80,6 +80,8 @@ window.swarm.publishFiles({ files })              // swarm_publishFiles
 window.swarm.getUploadStatus({ tagUid })          // swarm_getUploadStatus
 window.swarm.createFeed({ name })                 // swarm_createFeed
 window.swarm.updateFeed({ feedId, reference })    // swarm_updateFeed
+window.swarm.writeFeedEntry({ name, data })       // swarm_writeFeedEntry
+window.swarm.readFeedEntry({ name, owner })       // swarm_readFeedEntry
 ```
 
 Each convenience method MUST be equivalent to calling `window.swarm.request()` with the corresponding method name and parameters.
@@ -125,6 +127,20 @@ Errors MUST follow the [JSON-RPC 2.0 error format](https://www.jsonrpc.org/speci
 | -32603 | Internal Error | An unexpected error occurred in the provider. |
 
 Error codes 4001, 4100, 4200, and 4900 are aligned with the [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) and [EIP-1474](https://eips.ethereum.org/EIPS/eip-1474) error code ranges.
+
+#### Structured Error Reasons
+
+For `-32602` (Invalid Params) errors, implementations SHOULD include a `data.reason` field to enable programmatic error handling:
+
+| Reason | Applicable Methods | Meaning |
+|---|---|---|
+| `feed_empty` | `swarm_readFeedEntry` | Feed exists but has no entries (latest-entry read). |
+| `entry_not_found` | `swarm_readFeedEntry` | No entry at the requested index. |
+| `feed_not_found` | `swarm_readFeedEntry`, `swarm_writeFeedEntry` | Feed not found in local store or does not exist. |
+| `index_already_exists` | `swarm_writeFeedEntry` | An entry already exists at the explicit index (overwrite protection). |
+| `payload_too_large` | `swarm_publishData`, `swarm_writeFeedEntry` | Payload exceeds the maximum allowed size. |
+| `invalid_topic` | `swarm_readFeedEntry` | Topic is not a valid 64-character hex string. |
+| `invalid_owner` | `swarm_readFeedEntry` | Owner is missing (when required) or not a valid address. |
 
 ---
 
@@ -357,13 +373,110 @@ Update a feed to point at a new content reference.
 {
   feedId: string,    // The feed name
   reference: string, // The new content reference
-  bzzUrl: string     // "bzz://<manifestReference>" (stable feed URL)
+  bzzUrl: string,    // "bzz://<manifestReference>" (stable feed URL)
+  index: number      // The sequence index that was written
 }
 ```
 
 **Errors:** `4100` if not connected or feed access not granted, `4900` if node unavailable, `-32602` if params invalid or feed doesn't exist.
 
-**Failure semantics:** Swarm feeds use sequence-based indexing. If the underlying feed write succeeds on the node but the response is lost (e.g., due to a network timeout), retrying `swarm_updateFeed` with the same reference SHOULD be safe — implementations SHOULD detect that the feed already points to the requested reference and return success without writing a duplicate sequence entry.
+**Behavior:**
+- Writes are serialized per-topic (same mutex as `swarm_writeFeedEntry`). The returned `index` reflects the actual sequence index written.
+
+---
+
+#### `swarm_writeFeedEntry`
+
+Write an arbitrary payload directly to a feed index as a Single Owner Chunk (SOC).
+
+This enables the **journal pattern** — an append-only log where each entry is an independently-addressed chunk at an incrementing index. Unlike `swarm_updateFeed` (which stores a 32-byte content reference), `swarm_writeFeedEntry` stores the payload directly in the SOC. For payloads larger than the 4 KB SOC limit, the underlying implementation uploads the data separately and wraps the root chunk into the SOC transparently.
+
+**Params:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Feed name (same namespace as `swarm_createFeed`). The feed must already exist. |
+| `data` | `string \| Uint8Array \| ArrayBuffer` | Yes | The payload to write. Strings are encoded as UTF-8. |
+| `index` | `number` | No | Explicit index to write at. If omitted, auto-increments to the next available index. |
+
+**Result:**
+
+```javascript
+{
+  index: number   // The feed index that was written
+}
+```
+
+**Errors:** `4100` if not connected or feed access not granted, `4900` if node unavailable, `-32602` if params invalid, feed doesn't exist, index is occupied (`index_already_exists`), or payload exceeds SOC size limit (`payload_too_large`).
+
+**Behavior:**
+
+- The feed MUST already exist (created via `swarm_createFeed`).
+- If `index` is omitted, the provider MUST resolve the next available index and write at that index. The resolved index is returned.
+- If `index` is provided, the provider MUST check whether an entry already exists at that index. If it does, the write MUST be rejected with error data `{ reason: "index_already_exists" }`. This overwrite protection is the core safety guarantee of the journal pattern.
+- The overwrite check and the write MUST be atomic — implementations MUST NOT allow concurrent writes to race between the check and the write to the same index. A per-topic serialization mechanism (e.g., a mutex) is RECOMMENDED.
+- Sparse indices are valid. Writing to index 1000 without indices 0–999 existing is allowed. Applications that want sequential journal semantics SHOULD omit `index` and rely on auto-increment.
+
+**Write serialization:** Implementations MUST serialize writes to the same feed topic. Two concurrent `swarm_writeFeedEntry` calls to the same feed MUST NOT produce index collisions. Writes to different feeds MAY execute in parallel.
+
+---
+
+#### `swarm_readFeedEntry`
+
+Read a feed entry at a specific index, or read the latest entry. This is a read-only operation that does NOT require feed-level permission — only a basic connection (`swarm_requestAccess`).
+
+**Params:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `topic` | `string` | Conditional | 64-character hex topic. Required if `name` is not provided. |
+| `name` | `string` | Conditional | Feed name (same namespace as `swarm_createFeed`). Required if `topic` is not provided. |
+| `owner` | `string` | Conditional | Ethereum address of the feed owner (signer). See owner resolution rules below. |
+| `index` | `number` | No | Specific index to read. If omitted, reads the latest entry. |
+
+Exactly one of `topic` or `name` MUST be provided:
+- **`topic`**: Raw 64-character hex topic. The provider constructs the topic directly from these bytes (no hashing). Use this to read feeds created by other origins or other users. `owner` is required.
+- **`name`**: Feed name string. The provider derives the topic by hashing: `keccak256(normalizedOrigin + "/" + name)`. Use this to read your own feeds.
+
+**Owner resolution:**
+- When using `topic`: `owner` is required.
+- When using `name` without `owner`: The provider looks up the owner from its local feed store (populated when `swarm_createFeed` was called). No vault unlock or signing is needed — this is a metadata lookup.
+- When using `name` with `owner`: The provided owner is used. This allows reading another user's feed that shares the same app-scoped topic derivation.
+
+**Result:**
+
+```javascript
+{
+  data: string,           // Base64-encoded payload
+  encoding: "base64",     // Explicit encoding identifier
+  index: number,          // The index that was read
+  nextIndex: number|null  // Next writable index (only present when reading the latest entry)
+}
+```
+
+**Why base64:** The payload traverses process boundaries (main process → renderer → page context) via IPC and `postMessage`. Binary payloads do not survive this chain intact. Base64 is the safe universal encoding. The caller decodes:
+
+```javascript
+const bytes = Uint8Array.from(atob(result.data), c => c.charCodeAt(0))
+const text = new TextDecoder().decode(bytes)
+```
+
+**Errors:** `4100` if not connected, `4900` if node unreachable, `-32602` if params invalid.
+
+Structured error reasons in `data.reason`:
+
+| Reason | Meaning |
+|---|---|
+| `feed_empty` | The feed exists but has no entries written yet (returned for latest-entry reads). |
+| `entry_not_found` | No entry exists at the requested index. |
+| `feed_not_found` | Used `name` without `owner`, but the feed has not been created yet under this origin. |
+
+**Behavior:**
+
+- This method does NOT require feed-level permission — only connection permission (`swarm_requestAccess`). Feeds are public data on Swarm; the connection gate ensures the origin has been approved to use the user's Bee node.
+- Pre-flight checks MUST be limited to verifying the Bee node's HTTP API is reachable. Mode checks (ultra-light), readiness checks, and stamp checks MUST NOT be applied — reads work regardless of node mode and do not consume stamps.
+- Implementations MUST distinguish "not found" errors (HTTP 404/500 from the Bee API) from transient errors (network timeouts, internal failures). Transient errors MUST propagate as `-32603` (Internal Error), NOT be misclassified as `feed_empty` or `entry_not_found`.
+- When reading the latest entry (`index` omitted), `nextIndex` indicates the next index available for writing. When reading a specific index, `nextIndex` is `null`.
 
 ---
 
@@ -391,8 +504,9 @@ The key insight: the origin is derived from the **user-visible URL** (the addres
 
 1. **Connection:** Granted via `swarm_requestAccess`. Persisted per-origin.
 2. **Publish:** Each `swarm_publishData`/`swarm_publishFiles` call MAY require per-operation user approval, unless the user has opted into auto-approve for this origin.
-3. **Feeds:** Feed operations (`swarm_createFeed`, `swarm_updateFeed`) require an additional feed-specific permission grant, separate from the connection permission.
-4. **Disconnection:** The user can revoke access at any time. The provider MUST emit a `disconnect` event and reject subsequent requests with error code `4100`.
+3. **Feed writes:** Feed write operations (`swarm_createFeed`, `swarm_updateFeed`, `swarm_writeFeedEntry`) require an additional feed-specific permission grant, separate from the connection permission.
+4. **Feed reads:** `swarm_readFeedEntry` requires only connection permission — no feed grant is needed. Swarm feeds are public data; any connected origin can read any feed if it knows the owner address and topic.
+5. **Disconnection:** The user can revoke access at any time. The provider MUST emit a `disconnect` event and reject subsequent requests with error code `4100`.
 
 #### Auto-Approve (OPTIONAL)
 
@@ -439,6 +553,22 @@ Without app-scoped identities, any dApp with feed permission could create feeds 
 
 Feeds involve key material (signing) and have long-term implications (the feed URL is permanent, updates are irrevocable). This warrants a separate, more deliberate permission grant beyond "allow this site to upload data."
 
+### Why indexed feed entries alongside `updateFeed`?
+
+`swarm_updateFeed` treats a feed as a mutable pointer — it stores a 32-byte Swarm reference at the next sequence index. This is ideal for "latest version" use cases (e.g., a website, a profile).
+
+Many applications also need an **append-only log**: user activity feeds, message history, notification streams. Without indexed entry access, applications must implement a fragile "read current blob → append → re-upload entire blob → update feed" pattern. If the read fails (404, network blip), the entire history is silently overwritten.
+
+`swarm_writeFeedEntry` and `swarm_readFeedEntry` expose the native Swarm feed index, enabling O(1) appends (write one SOC, no reads) and O(N) parallel reconstruction (fetch individual entries by index). The overwrite protection on explicit indices ensures the core safety guarantee: no silent history corruption.
+
+### Why do feed reads not require feed permission?
+
+Swarm feeds are public data — anyone who knows the owner address and topic can read any feed entry on the network. The connection permission gate (`swarm_requestAccess`) ensures the origin has been approved to route requests through the user's Bee node. Adding a per-feed read ACL would be security theater: the same data is accessible via any other Bee node or gateway. Keeping reads lightweight (connection-only, no vault unlock, no stamps check) enables use cases like profile pages and cross-user activity views without unnecessary permission prompts.
+
+### Why base64 for read responses?
+
+Feed entry payloads are arbitrary bytes. The response travels from the Bee node through the main process, across IPC to the renderer, and via `postMessage` to the page context. Binary data (`Uint8Array`) does not survive this serialization chain intact across all environments. Base64 is the safe universal encoding. The `encoding: "base64"` field makes the contract explicit so callers know exactly how to decode.
+
 ## Backwards Compatibility
 
 This SWIP introduces a new API surface. There are no backwards compatibility concerns as no prior standard for `window.swarm` exists. Implementations that predate this specification SHOULD migrate to conform to these interfaces.
@@ -484,6 +614,7 @@ The following capabilities are anticipated for future versions of this specifica
 - **`swarm_listFeeds`** — Enumerate existing feeds for the calling origin. This would allow dApps to discover feeds without maintaining their own registry of feed names.
 - **`capabilitiesChanged` event** — Proactive notification when the provider's capabilities change (e.g., node goes offline, stamps exhausted). Currently dApps must poll `swarm_getCapabilities` to detect state changes.
 - **`preferredIdentityMode` parameter for `swarm_createFeed`** — Allow dApps to express a preference for `app-scoped` or `bee-wallet` identity mode, rather than relying solely on user/implementation choice.
+- **`encoding` parameter for `swarm_readFeedEntry`** — Allow callers to request a specific response encoding (e.g., `"utf8"`) to avoid manual base64 decoding for text payloads.
 
 Additionally, the `specVersion` field in `swarm_getCapabilities` is currently a SHOULD. A future revision may promote it to MUST once multiple implementations exist and version negotiation becomes necessary.
 
@@ -557,6 +688,7 @@ const updated = await window.swarm.updateFeed({
   reference: content.reference,
 });
 assert(updated.bzzUrl === feed.bzzUrl); // Same stable URL
+assert(typeof updated.index === 'number'); // Sequence index returned
 ```
 
 ### Error Handling
@@ -601,6 +733,105 @@ const feed2 = await window.swarm.createFeed({ name: 'my-blog' });
 assert(feed1.manifestReference === feed2.manifestReference);
 assert(feed1.owner === feed2.owner);
 assert(feed1.topic === feed2.topic);
+```
+
+### Feed Journal (Write and Read Entries)
+
+```javascript
+// Create feed first
+const feed = await window.swarm.createFeed({ name: 'activity' });
+
+// Write entries (auto-increment)
+const w0 = await window.swarm.writeFeedEntry({
+  name: 'activity',
+  data: JSON.stringify({ action: 'post', id: 1 }),
+});
+assert(w0.index === 0);
+
+const w1 = await window.swarm.writeFeedEntry({
+  name: 'activity',
+  data: JSON.stringify({ action: 'post', id: 2 }),
+});
+assert(w1.index === 1);
+
+// Read latest entry
+const latest = await window.swarm.readFeedEntry({ name: 'activity' });
+assert(latest.encoding === 'base64');
+assert(latest.index === 1);
+assert(latest.nextIndex === 2);
+
+// Decode the payload
+const bytes = Uint8Array.from(atob(latest.data), c => c.charCodeAt(0));
+const entry = JSON.parse(new TextDecoder().decode(bytes));
+assert(entry.action === 'post');
+assert(entry.id === 2);
+
+// Read specific index
+const first = await window.swarm.readFeedEntry({ name: 'activity', index: 0 });
+assert(first.index === 0);
+
+// Read all entries in parallel
+const all = await Promise.all(
+  Array.from({ length: latest.nextIndex }, (_, i) =>
+    window.swarm.readFeedEntry({ name: 'activity', index: i })
+  )
+);
+assert(all.length === 2);
+```
+
+### Feed Journal — Overwrite Protection
+
+```javascript
+// Writing at an occupied index is rejected
+await window.swarm.writeFeedEntry({ name: 'activity', data: 'first', index: 0 });
+try {
+  await window.swarm.writeFeedEntry({ name: 'activity', data: 'duplicate', index: 0 });
+  assert.fail('Should have thrown');
+} catch (err) {
+  assert(err.code === -32602);
+  assert(err.data.reason === 'index_already_exists');
+}
+```
+
+### Feed Journal — Cross-User Read
+
+```javascript
+// Read another user's feed using raw topic + owner from their published objects
+const otherUserEntry = await window.swarm.readFeedEntry({
+  topic: 'a1b2c3...64-char-hex-topic...',
+  owner: '0xOtherUserSignerAddress',
+  index: 0,
+});
+assert(otherUserEntry.encoding === 'base64');
+assert(typeof otherUserEntry.index === 'number');
+```
+
+### Feed Journal — Empty Feed
+
+```javascript
+// Reading latest from empty feed returns structured error
+await window.swarm.createFeed({ name: 'empty-feed' });
+try {
+  await window.swarm.readFeedEntry({ name: 'empty-feed' });
+  assert.fail('Should have thrown');
+} catch (err) {
+  assert(err.code === -32602);
+  assert(err.data.reason === 'feed_empty');
+}
+```
+
+### Feed Read Without Feed Grant
+
+```javascript
+// readFeedEntry requires only connection, not feed grant
+// (assuming connected but no feed permission granted)
+const entry = await window.swarm.readFeedEntry({
+  topic: 'a1b2c3...64-char-hex-topic...',
+  owner: '0xSomeAddress',
+  index: 0,
+});
+// Should succeed — feed grant not required for reads
+assert(typeof entry.data === 'string');
 ```
 
 ### Re-Connection Without Re-Prompt

--- a/SWIPs/swip-draft_provider_api.md
+++ b/SWIPs/swip-draft_provider_api.md
@@ -51,9 +51,7 @@ if (typeof window.swarm !== 'undefined') {
 
 #### Properties
 
-| Property | Type | Description |
-|---|---|---|
-| `isFreedomBrowser` | `boolean` | **(OPTIONAL, implementation-specific)** Implementations MAY include a boolean property identifying themselves. This is NOT part of the standard interface and MUST NOT be relied upon for feature detection. Use `swarm_getCapabilities` instead. |
+Implementations MAY include additional boolean properties identifying themselves (e.g., `isFreedomBrowser`). These are NOT part of the standard interface and MUST NOT be relied upon for feature detection. Use `swarm_getCapabilities` for capability discovery.
 
 > **Note:** Future versions of this specification may define a standard `isSwarmProvider` property or a capability-based detection mechanism.
 
@@ -72,7 +70,7 @@ The method MUST return a `Promise` that resolves with the method's result, or re
 
 ### Convenience Methods
 
-Implementations SHOULD expose convenience wrappers for each standard method:
+Implementations MUST expose convenience wrappers for each standard method:
 
 ```javascript
 window.swarm.requestAccess()                     // swarm_requestAccess
@@ -84,7 +82,7 @@ window.swarm.createFeed({ name })                 // swarm_createFeed
 window.swarm.updateFeed({ feedId, reference })    // swarm_updateFeed
 ```
 
-These MUST be equivalent to calling `window.swarm.request()` with the corresponding method name.
+Each convenience method MUST be equivalent to calling `window.swarm.request()` with the corresponding method name and parameters.
 
 ### Events
 
@@ -151,7 +149,7 @@ Requests the user's permission to interact with their Swarm node from this origi
 **Errors:** `4001` if the user rejects.
 
 **Behavior:**
-- Calling `swarm_requestAccess` when already connected SHOULD return the existing connection state without re-prompting.
+- Calling `swarm_requestAccess` when already connected MUST return the existing connection state without re-prompting.
 - After a successful `swarm_requestAccess`, the provider MUST emit a `connect` event.
 
 ---
@@ -166,6 +164,7 @@ Returns the current capabilities of the provider for this origin. Does NOT requi
 
 ```javascript
 {
+  specVersion: string,     // Specification version (e.g. "1.0")
   canPublish: boolean,     // true if connected AND node is ready
   reason: string | null,   // null if canPublish is true, otherwise a reason code
   limits: {
@@ -186,6 +185,8 @@ Returns the current capabilities of the provider for this origin. Does NOT requi
 | `"node-not-ready"` | Node is running but not yet synced/ready. |
 | `"no-usable-stamps"` | No postage stamps with remaining capacity. |
 
+**`specVersion`:** The version of this specification that the provider implements. This SWIP defines version `"1.0"`. Implementations SHOULD return this field regardless of whether the origin has called `swarm_requestAccess`. DApps can use this field to detect available features and adapt to different provider versions.
+
 ---
 
 #### `swarm_publishData`
@@ -196,7 +197,7 @@ Upload a single blob of data to Swarm.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `data` | `string \| Uint8Array \| ArrayBuffer` | Yes | The content to upload. |
+| `data` | `string \| Uint8Array \| ArrayBuffer` | Yes | The content to upload. Strings are encoded as UTF-8. |
 | `contentType` | `string` | Yes | MIME type (e.g. `"text/html"`, `"application/json"`). |
 | `name` | `string` | No | Display name for the upload. |
 
@@ -208,6 +209,8 @@ Upload a single blob of data to Swarm.
   bzzUrl: string       // "bzz://<reference>"
 }
 ```
+
+> **Note on `bzz://` URLs:** The `bzz://` URI scheme is a Swarm convention for content-addressed references. It is not an IANA-registered scheme. Implementations resolve `bzz://` URLs through a local Bee gateway or native protocol handler.
 
 **Errors:** `4100` if not connected, `4900` if node unavailable, `-32602` if params invalid or payload exceeds `maxDataBytes`.
 
@@ -286,6 +289,8 @@ Query the upload progress of a previously initiated file upload.
 
 **Security:** Implementations MUST enforce origin-scoped tag ownership. A page MUST NOT be able to query upload status for tags created by a different origin. This prevents cross-origin upload snooping.
 
+**Persistence:** Tag ownership is session-scoped. Upload status for tags created in a previous browser session MAY be unavailable. Implementations are NOT REQUIRED to persist tag ownership across restarts.
+
 ---
 
 #### `swarm_createFeed`
@@ -357,6 +362,8 @@ Update a feed to point at a new content reference.
 ```
 
 **Errors:** `4100` if not connected or feed access not granted, `4900` if node unavailable, `-32602` if params invalid or feed doesn't exist.
+
+**Failure semantics:** Swarm feeds use sequence-based indexing. If the underlying feed write succeeds on the node but the response is lost (e.g., due to a network timeout), retrying `swarm_updateFeed` with the same reference SHOULD be safe — implementations SHOULD detect that the feed already points to the requested reference and return success without writing a duplicate sequence entry.
 
 ---
 
@@ -437,6 +444,50 @@ Feeds involve key material (signing) and have long-term implications (the feed U
 This SWIP introduces a new API surface. There are no backwards compatibility concerns as no prior standard for `window.swarm` exists. Implementations that predate this specification SHOULD migrate to conform to these interfaces.
 
 Web pages that do not use `window.swarm` are unaffected. The provider MUST NOT modify any existing browser APIs or globals.
+
+## Security Considerations
+
+### Origin Trust Model
+
+The provider relies on the host application (browser) to supply the correct origin for each request. If the host misidentifies a page's origin, the entire permission model breaks. Implementations MUST derive the origin from the user-visible URL (address bar), not from `window.location` or any value the page can control. The page context MUST NOT be able to influence its own origin identification.
+
+### Resource Exhaustion
+
+A connected origin could repeatedly publish data up to the size limit, consuming postage stamp capacity and local storage. Implementations SHOULD consider:
+
+- **Rate limiting:** Throttling publish requests per origin per time window.
+- **Stamp monitoring:** Warning the user when stamp capacity is running low due to dApp activity.
+- **Per-origin accounting:** Tracking cumulative usage per origin so users can identify heavy consumers.
+
+This specification does not mandate a specific rate-limiting scheme, as appropriate limits depend on the node's capacity and the user's preferences.
+
+### Iframe and Nested Context Behavior
+
+This specification does not define behavior for `window.swarm` inside iframes or nested browsing contexts. Implementations SHOULD restrict provider availability to the top-level browsing context. If an implementation chooses to expose the provider to iframes, the iframe's origin MUST be evaluated independently — it MUST NOT inherit the parent frame's permissions.
+
+### Feed Key Material
+
+App-scoped feed identities involve derived signing keys. Implementations MUST ensure that:
+
+- Private key material is never exposed to the page context.
+- Key derivation is deterministic (same origin always produces the same key) but not reversible (the page cannot derive the master key from its app-scoped key).
+- Feed signing occurs in a trusted context (main process or secure enclave), never in the renderer or page context.
+
+### Temporary Artifacts
+
+Implementations that create temporary files or directories during upload processing (e.g., for `swarm_publishFiles` manifest construction) MUST clean up these artifacts regardless of whether the upload succeeds or fails.
+
+## Future Extensions
+
+The following capabilities are anticipated for future versions of this specification and are explicitly out of scope for version 1.0:
+
+- **`swarm_listFeeds`** — Enumerate existing feeds for the calling origin. This would allow dApps to discover feeds without maintaining their own registry of feed names.
+- **`capabilitiesChanged` event** — Proactive notification when the provider's capabilities change (e.g., node goes offline, stamps exhausted). Currently dApps must poll `swarm_getCapabilities` to detect state changes.
+- **`preferredIdentityMode` parameter for `swarm_createFeed`** — Allow dApps to express a preference for `app-scoped` or `bee-wallet` identity mode, rather than relying solely on user/implementation choice.
+
+Additionally, the `specVersion` field in `swarm_getCapabilities` is currently a SHOULD. A future revision may promote it to MUST once multiple implementations exist and version negotiation becomes necessary.
+
+Implementations MAY experiment with these features, but they are not part of the 1.0 standard interface and MUST NOT be required for conformance.
 
 ## Test Cases
 
@@ -528,17 +579,65 @@ try {
 }
 ```
 
+### Post-Disconnect Behavior
+
+```javascript
+// After user revokes access, all methods reject with 4100
+// (simulate disconnect via browser UI, then:)
+try {
+  await window.swarm.publishData({ data: 'test', contentType: 'text/plain' });
+  assert.fail('Should have thrown');
+} catch (err) {
+  assert(err.code === 4100); // Unauthorized
+}
+```
+
+### Feed Idempotency
+
+```javascript
+// Creating the same feed twice returns identical metadata
+const feed1 = await window.swarm.createFeed({ name: 'my-blog' });
+const feed2 = await window.swarm.createFeed({ name: 'my-blog' });
+assert(feed1.manifestReference === feed2.manifestReference);
+assert(feed1.owner === feed2.owner);
+assert(feed1.topic === feed2.topic);
+```
+
+### Re-Connection Without Re-Prompt
+
+```javascript
+// Second requestAccess call returns existing state without prompting
+const first = await window.swarm.requestAccess();
+const second = await window.swarm.requestAccess();
+assert(second.connected === true);
+assert(second.origin === first.origin);
+```
+
+### Capabilities Before Connection
+
+```javascript
+// getCapabilities works without prior requestAccess
+const caps = await window.swarm.getCapabilities();
+assert(caps.canPublish === false);
+assert(caps.reason === 'not-connected');
+assert(typeof caps.limits.maxDataBytes === 'number');
+// specVersion is optional (SHOULD) in 1.0
+if (caps.specVersion) assert(typeof caps.specVersion === 'string');
+```
+
 ## Implementation
 
 A reference implementation exists in [Freedom Browser](https://github.com/solardev-xyz/freedom-browser) (PR [#19](https://github.com/solardev-xyz/freedom-browser/pull/19)):
 
-- **Provider injection:** [`src/main/webview-preload.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing/src/main/webview-preload.js) — `window.swarm` object injected into webview page context
-- **Main-process enforcement:** [`src/main/swarm/swarm-provider-ipc.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing/src/main/swarm/swarm-provider-ipc.js) — method dispatch, validation, origin enforcement
-- **Publishing:** [`src/main/swarm/publish-service.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing/src/main/swarm/publish-service.js) — data and file uploads via `bee-js`
-- **Feeds:** [`src/main/swarm/feed-service.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing/src/main/swarm/feed-service.js) — feed creation and updates
-- **Permissions:** [`src/main/swarm/swarm-permissions.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing/src/main/swarm/swarm-permissions.js) — origin-scoped permission store
-- **Origin normalization:** [`src/shared/origin-utils.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing/src/shared/origin-utils.js) — dweb-aware origin extraction
-- **Test page:** [`docs/swarm-provider-test/index.html`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing/docs/swarm-provider-test/index.html) — interactive test harness
+- **Provider injection:** [`src/main/webview-preload.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing-updated/src/main/webview-preload.js) — `window.swarm` object injected into webview page context
+- **Main-process enforcement:** [`src/main/swarm/swarm-provider-ipc.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing-updated/src/main/swarm/swarm-provider-ipc.js) — method dispatch, validation, origin enforcement
+- **Publishing:** [`src/main/swarm/publish-service.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing-updated/src/main/swarm/publish-service.js) — data and file uploads via `bee-js`
+- **Feeds:** [`src/main/swarm/feed-service.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing-updated/src/main/swarm/feed-service.js) — feed creation and updates
+- **Permissions:** [`src/main/swarm/swarm-permissions.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing-updated/src/main/swarm/swarm-permissions.js) — origin-scoped permission store
+- **Origin normalization:** [`src/shared/origin-utils.js`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing-updated/src/shared/origin-utils.js) — dweb-aware origin extraction
+- **Test page:** [`docs/swarm-provider-test/index.html`](https://github.com/solardev-xyz/freedom-browser/blob/feature/swarm-publishing-updated/docs/swarm-provider-test/index.html) — interactive test harness
+
+A reference dApp consuming this API exists in [Swarmit](https://github.com/solardev-xyz/swarmit), a decentralized message board that uses `swarm_requestAccess`, `swarm_publishData`, `swarm_createFeed`, and `swarm_updateFeed` for its full publishing pipeline.
 
 ## Copyright
 

--- a/SWIPs/swip-draft_provider_api_messaging.md
+++ b/SWIPs/swip-draft_provider_api_messaging.md
@@ -1,0 +1,672 @@
+---
+SWIP: <to be assigned>
+title: Swarm Provider API — Messaging Extension (PSS & GSOC)
+author: Florian Glatz (@heckerhut)
+discussions-to: https://discord.com/channels/799027393297514537/1239813439136993280
+status: Draft
+type: Standards Track
+category: Interface
+created: 2026-07-13
+requires: <Swarm Provider API SWIP>
+---
+
+## Simple Summary
+
+An extension to the [Swarm Provider API (`window.swarm`)](./swip-draft_provider_api.md)
+that adds **real-time messaging**: encrypted point-to-point delivery (PSS) and
+topic broadcast (GSOC), including a **subscription primitive** for receiving
+pushed messages — the first streaming surface in the provider API, which is
+otherwise entirely request/response.
+
+## Abstract
+
+The core Swarm Provider API specifies fifteen request/response RPC methods and
+two lifecycle events (`connect`, `disconnect`). It has no way for a web
+application to *receive* asynchronous data: every method resolves once, and the
+only push signals concern the connection itself. Real-time applications —
+collaborative editors, chat, presence, live dashboards — need a channel over
+which the node delivers incoming messages as they arrive.
+
+This extension adds that channel. It specifies:
+
+- **`swarm_subscribe` / `swarm_unsubscribe`** — open and close a long-lived
+  subscription to a GSOC address (topic broadcast) or a PSS topic
+  (point-to-point inbox). Delivery is via a new **`message`** event, following
+  the subscription-id + event pattern established by
+  [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193)'s `eth_subscribe`.
+- **`swarm_sendPss`** — send an encrypted point-to-point message to a recipient
+  identified by their PSS public key.
+- **`swarm_sendGsoc`** — broadcast a message on a topic that any subscriber to
+  the derived GSOC address receives.
+- **`swarm_getMessagingIdentity`** — disclose this origin's PSS public key and
+  overlay, so peers can address messages to it.
+
+PSS and GSOC are existing Swarm/Bee primitives; this extension does not define
+them, only their exposure at the provider boundary with consent and
+origin-scoping consistent with the core specification. Messages are best-effort,
+unordered, and may be duplicated; applications requiring ordering or exactly-once
+semantics MUST layer that themselves (a CRDT such as Yjs satisfies this
+naturally).
+
+## Motivation
+
+The core API's request/response shape is a deliberate, minimal foundation, but
+it structurally cannot express "tell me when something arrives." Applications
+work around this by polling — repeatedly reading a feed or SOC on a timer —
+which trades latency for request volume and never reaches interactive speed. A
+collaborative document synced by polling feeds every few seconds is usable for
+asynchronous editing but cannot show live cursors or keystroke-level updates.
+
+Swarm already has the transport primitives for real-time messaging:
+
+- **PSS** (Postal Service over Swarm): trojan chunks encrypted to a recipient's
+  public key and routed toward a neighborhood — encrypted, sender-anonymous,
+  point-to-point.
+- **GSOC** (Graffiti Single Owner Chunk): a Single Owner Chunk at a
+  deterministically-derivable address that many parties can write to and
+  subscribe to — a broadcast "mailbox at a well-known address."
+
+Historically these required a full node to *receive* (Bee has no push delivery
+to light nodes). Light-node implementations can now receive by pulling from the
+target neighborhood and decrypting locally, making send **and** receive viable
+on the kind of light/ultra-light node a browser embeds. This extension exposes
+that capability to dApps so the decentralized web gains real-time collaboration
+without a coordination server.
+
+### Design Goals
+
+Identical to the core specification, plus:
+
+- **One new interaction pattern, minimally.** Add exactly one streaming shape
+  (subscription-id + `message` event), reusing EIP-1193 precedent, rather than
+  several bespoke callback styles.
+- **Hide protocol mechanics.** DApps address a *topic* or a *recipient key*; the
+  provider handles trojan construction, neighborhood targeting, GSOC owner
+  mining, nonce mining, encryption, and the receive pipeline.
+- **Tolerate an unreliable substrate honestly.** The API surfaces best-effort,
+  unordered, at-least-once delivery as such and does not pretend otherwise.
+
+## Specification
+
+This document is an **extension**. It adds methods, one event, error reasons,
+capability fields, and one permission tier to the core Swarm Provider API. It
+changes none of the existing method semantics. An implementation MAY conform to
+the core specification without this extension; an implementation of this
+extension MUST also conform to the core specification.
+
+### Feature Detection
+
+Because this extension is optional, dApps MUST NOT assume its presence from the
+core `specVersion` alone. The core `swarm_getCapabilities` result is extended
+with a `features` array; an implementation of this extension MUST include the
+string `"messaging"` in it:
+
+```javascript
+const caps = await window.swarm.getCapabilities()
+if (caps.features?.includes('messaging')) {
+  // PSS/GSOC methods are available
+}
+```
+
+`swarm_getCapabilities` is additionally extended with messaging limits (see
+[Limits](#limits)). Both `features` and the new limit fields MAY be returned
+before `swarm_requestAccess` (they are static capability facts).
+
+### Convenience Methods
+
+Implementations of this extension MUST expose these convenience wrappers, in
+addition to the core set:
+
+```javascript
+window.swarm.getMessagingIdentity()                        // swarm_getMessagingIdentity
+window.swarm.subscribe({ kind, topic })                    // swarm_subscribe
+window.swarm.unsubscribe({ subscriptionId })               // swarm_unsubscribe
+window.swarm.sendPss({ topic, recipient, data })           // swarm_sendPss
+window.swarm.sendGsoc({ topic, data })                     // swarm_sendGsoc
+```
+
+Each MUST be equivalent to calling `window.swarm.request()` with the
+corresponding method name and params.
+
+### Events
+
+This extension adds one standard event:
+
+| Event | Data | Description |
+|---|---|---|
+| `message` | `SubscriptionMessage` (below) | Emitted for each message delivered on any active subscription owned by the calling origin. |
+
+**`SubscriptionMessage`:**
+
+```javascript
+{
+  type: "swarm_subscription",   // constant; disambiguates from other future event payloads
+  subscription: string,          // the subscriptionId this message belongs to
+  result: {
+    kind: "gsoc" | "pss",       // matches the subscription kind
+    key: string,                 // GSOC: the 64-hex SOC address; PSS: the 64-hex topic
+    data: string,                // base64-encoded decrypted payload
+    encoding: "base64",
+    receivedAt: number           // ms unix timestamp the provider received it
+  }
+}
+```
+
+The `message` event MUST fire only for subscriptions created by the calling
+origin (origin-scoped, same isolation as feeds and tags). An implementation MUST
+NOT deliver a message to an origin that did not open the corresponding
+subscription.
+
+Consistent with EIP-1193, `swarm.on('message', handler)`,
+`swarm.removeListener('message', handler)`, and `swarm.removeAllListeners('message')`
+MUST be supported.
+
+### Error Format
+
+Unchanged from the core specification. This extension reuses the standard error
+codes (`4001`, `4100`, `4200`, `4900`, `-32602`, `-32603`) and adds the
+following `data.reason` values for `-32602` (Invalid Params):
+
+| Reason | Applicable Methods | Meaning |
+|---|---|---|
+| `invalid_topic` | `swarm_subscribe`, `swarm_sendPss`, `swarm_sendGsoc` | Topic is missing or not a valid non-empty string / 64-char hex where hex is required. |
+| `invalid_address` | `swarm_subscribe` | An explicit GSOC `address` is not a valid 64-char hex. |
+| `invalid_recipient` | `swarm_sendPss` | Recipient public key is missing or not a valid 33-byte compressed secp256k1 key (66-char hex). |
+| `invalid_kind` | `swarm_subscribe` | `kind` is not `"gsoc"` or `"pss"`. |
+| `payload_too_large` | `swarm_sendPss`, `swarm_sendGsoc` | Payload exceeds `maxMessageBytes`. |
+| `subscription_not_found` | `swarm_unsubscribe` | No active subscription with the given id for this origin. |
+| `too_many_subscriptions` | `swarm_subscribe` | The origin has reached `maxSubscriptions`. |
+| `unsupported_option` | messaging methods accepting `options` | An unrecognized option field was supplied. |
+
+A subscription whose underlying receive pipeline fails after being established
+(e.g. the node loses connectivity) MUST NOT silently stop. The provider SHOULD
+emit a `message` with a transport-level error indicator OR emit `disconnect`
+semantics per the core spec; at minimum, implementations MUST document their
+failure signalling. (Normative signalling of mid-stream subscription errors is
+deferred to a future revision; see [Future Work](#future-work).)
+
+---
+
+### Methods
+
+#### `swarm_getMessagingIdentity`
+
+Return this origin's messaging identity — the PSS public key peers encrypt to,
+and the node overlay used for neighborhood targeting.
+
+Operates under the **messaging permission tier** (see [Permission Model](#permission-model)):
+the returned public key is a stable per-origin identifier, so disclosure
+requires consent, mirroring `swarm_getSigningIdentity` in the core spec.
+
+**Params:** None.
+
+**Result:**
+
+```javascript
+{
+  pssPublicKey: string,   // 66-char hex, 33-byte compressed secp256k1 public key
+  overlay: string,        // 64-char hex node overlay address (neighborhood targeting)
+  identityMode: string    // "app-scoped" or "bee-wallet" (as in the core spec)
+}
+```
+
+**Errors:** `4001` if the user rejects the messaging-permission prompt. `4100`
+if the origin lacks basic connection or a prompt cannot be surfaced. `4900` if
+the node is unavailable.
+
+**Behavior:**
+- If messaging permission has not been granted, the implementation MUST prompt
+  (same tier as the first `swarm_subscribe`/`swarm_send*` call) and return on
+  approval.
+- The `pssPublicKey` MUST be stable for the lifetime of the origin's messaging
+  grant. An `app-scoped` implementation SHOULD derive it per-origin so one dApp
+  cannot present another's messaging identity.
+- Whether the PSS key is bound to the same key as `swarm_getSigningIdentity`'s
+  `owner` is implementation-defined; dApps MUST NOT assume equality.
+
+---
+
+#### `swarm_subscribe`
+
+Open a long-lived subscription. Incoming messages are delivered via the
+[`message` event](#events), tagged with the returned `subscriptionId`.
+
+**Params:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `kind` | `"gsoc" \| "pss"` | Yes | Subscription type. |
+| `topic` | `string` | Conditional | GSOC: a topic string the provider deterministically maps to a GSOC address. PSS: the topic to receive on. Required unless a raw `address` is given for GSOC. |
+| `address` | `string` | Conditional | GSOC only. A raw 64-char hex GSOC/SOC address, for interoperating with GSOCs whose address was derived elsewhere. Mutually exclusive with `topic`. |
+| `options` | `object` | No | Reserved. Unknown fields rejected with `unsupported_option`. |
+
+**Result:**
+
+```javascript
+{
+  subscriptionId: string,   // opaque id, unique within this origin's session
+  kind: "gsoc" | "pss",
+  key: string               // resolved GSOC address (gsoc) or topic (pss), 64-char hex
+}
+```
+
+**Errors:** `4001` if the user rejects the messaging-permission prompt this call
+triggered. `4100` if the origin lacks basic connection or a prompt cannot be
+surfaced. `4900` if the node is unavailable. `-32602` for
+`invalid_kind`, `invalid_topic`, `invalid_address`, `too_many_subscriptions`,
+`unsupported_option`.
+
+**Behavior:**
+- Subscribing establishes a receive pipeline for the target neighborhood. The
+  implementation is responsible for pulling and decrypting matching chunks and
+  delivering decoded payloads via the `message` event.
+- **GSOC topic → address derivation MUST be deterministic** so that independent
+  parties passing the same `topic` subscribe to and send at the same address.
+  The derivation MUST be documented by the implementation and SHOULD match
+  bee-js `gsocMine` semantics for cross-implementation interop.
+- For PSS, only messages the node can decrypt (encrypted to this origin's PSS
+  key) are delivered. Undecryptable traffic in the neighborhood MUST NOT be
+  delivered.
+- The provider MUST deduplicate deliveries; the same message MUST NOT be
+  delivered twice for one subscription. (Across a resubscribe, redelivery is
+  permitted — see delivery semantics.)
+- Subscriptions are **origin-scoped** and **session-scoped**. They MUST be torn
+  down automatically when the page unloads (`pagehide`) and when access is
+  revoked (`disconnect`). Implementations are NOT REQUIRED to persist
+  subscriptions across page reloads.
+- Multiple subscriptions to the same key by one origin MAY be coalesced
+  internally but MUST each receive messages and MUST each be independently
+  addressable by `swarm_unsubscribe`.
+
+**Delivery semantics (normative):** Messages are **best-effort, unordered, and
+at-least-once**. A subscriber MAY miss messages published while it was not
+subscribed, MAY receive messages out of send order, and MAY (across
+resubscription) receive a message more than once. Applications MUST tolerate
+this. Ordering/causality and gap recovery are application concerns; the durable
+Swarm feed layer (core spec) is the appropriate substrate for authoritative
+state and catch-up, with messaging used for live propagation.
+
+---
+
+#### `swarm_unsubscribe`
+
+Close a subscription.
+
+**Params:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `subscriptionId` | `string` | Yes | An id returned by `swarm_subscribe` for this origin. |
+
+**Result:**
+
+```javascript
+{ unsubscribed: true }
+```
+
+**Errors:** `-32602` with `subscription_not_found` if no such active
+subscription exists for this origin. Unsubscribing an already-closed
+subscription MAY be treated as idempotent success or `subscription_not_found`;
+implementations SHOULD prefer idempotent success.
+
+**Behavior:**
+- After a successful unsubscribe, the `message` event MUST NOT fire for that
+  `subscriptionId`.
+- The provider SHOULD release the underlying receive pipeline when its last
+  subscriber for a neighborhood unsubscribes.
+
+---
+
+#### `swarm_sendPss`
+
+Send an encrypted point-to-point message to a recipient identified by their PSS
+public key. The message is a trojan chunk encrypted to the recipient and routed
+toward the neighborhood implied by `targets`.
+
+Operates under the **messaging send tier** (per-operation consent like publish;
+consumes a postage stamp).
+
+**Params:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `topic` | `string` | Yes | Topic the recipient subscribes on. Hashed/normalized by the provider as in Bee PSS. |
+| `recipient` | `string` | Yes | Recipient PSS public key: 66-char hex, 33-byte compressed secp256k1 (as returned by `swarm_getMessagingIdentity`). |
+| `targets` | `string` | No | Neighborhood prefix as hex (1–`maxTargetDepth` bytes). If omitted, the provider derives targeting from the recipient/overlay. Deeper targets = more precise routing, higher cost. |
+| `data` | `string \| Uint8Array \| ArrayBuffer` | Yes | Payload. Strings encoded UTF-8. MUST be ≤ `maxMessageBytes`. |
+| `options` | `object` | No | Reserved. Unknown fields rejected with `unsupported_option`. |
+
+**Result:**
+
+```javascript
+{ sent: true }
+```
+
+**Errors:** `4001` if the user rejects a per-send prompt. `4100` if not
+connected. `4900` if node unavailable or no usable postage stamp. `-32602` for
+`invalid_topic`, `invalid_recipient`, `invalid_target`, `payload_too_large`,
+`unsupported_option`.
+
+**Behavior:**
+- The provider constructs the trojan chunk (encryption to `recipient`, nonce
+  mining, targeting) and uploads it with an automatically-selected postage
+  batch. DApps do not manage batches or mining.
+- PSS is **fire-and-forget**: a successful result means the chunk was accepted
+  for upload, NOT that the recipient received it. There is no delivery receipt.
+- Payload confidentiality is provided by PSS encryption to the recipient key.
+  Sender anonymity properties are those of the underlying PSS primitive and are
+  not strengthened or weakened here.
+
+---
+
+#### `swarm_sendGsoc`
+
+Broadcast a message on a topic. Any origin subscribed (via `swarm_subscribe`
+with `kind: "gsoc"`) to the address the topic derives to receives it.
+
+Operates under the **messaging send tier**.
+
+**Params:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `topic` | `string` | Conditional | Topic the provider deterministically maps to a GSOC address (same derivation as `swarm_subscribe`). Required unless `address` is given. |
+| `address` | `string` | Conditional | Raw 64-char hex GSOC address. Mutually exclusive with `topic`. |
+| `data` | `string \| Uint8Array \| ArrayBuffer` | Yes | Payload. Strings encoded UTF-8. MUST be ≤ `maxMessageBytes`. |
+| `options` | `object` | No | Reserved. Unknown fields rejected with `unsupported_option`. |
+
+**Result:**
+
+```javascript
+{
+  sent: true,
+  address: string   // 64-char hex GSOC address written to
+}
+```
+
+**Errors:** `4001` if the user rejects a per-send prompt. `4100` if not
+connected. `4900` if node unavailable or no usable postage stamp. `-32602` for
+`invalid_topic`, `invalid_address`, `payload_too_large`, `unsupported_option`.
+
+**Behavior:**
+- GSOC send writes a Single Owner Chunk at the derived address. The provider
+  performs any required owner mining so the chunk lands in the correct
+  neighborhood, signs it, and uploads it with an automatically-selected batch.
+- Re-sending on the same topic overwrites the SOC at that address with a newer
+  timestamp (this is how a broadcast channel advances). Because delivery is
+  at-least-once and unordered, subscribers MUST NOT assume they observe every
+  intermediate value — only that they converge on recent ones. For a stream of
+  independent updates (e.g. CRDT deltas) where every value matters, senders
+  SHOULD vary the effective address per message (e.g. include a sequence or
+  random component in the topic) so updates do not clobber one another, or use
+  PSS. Implementations SHOULD document their GSOC addressing so applications can
+  reason about this.
+- Unlike the core `swarm_writeSingleOwnerChunk` (signed by the fixed origin
+  identity), GSOC uses a mined owner key derived for neighborhood placement;
+  this is why GSOC send is a distinct method rather than a use of the core SOC
+  write.
+
+---
+
+### Limits
+
+`swarm_getCapabilities().limits` is extended with:
+
+| Limit | Recommended Default | Notes |
+|---|---|---|
+| `maxMessageBytes` | 3584 | Max PSS/GSOC payload. A Swarm chunk is 4096 bytes; PSS/GSOC framing and encryption overhead reduce the usable payload. Implementations MUST advertise the true usable maximum. |
+| `maxTargetDepth` | 3 | Max neighborhood-prefix length in bytes for PSS `targets`. |
+| `maxSubscriptions` | 32 | Max concurrent active subscriptions per origin. |
+
+Applications needing to move more than `maxMessageBytes` in one logical message
+MUST chunk at the application layer, or publish the bulk via `swarm_publishData`
+and send only the resulting reference over messaging.
+
+### Permission Model
+
+This extension adds one tier to the core permission lifecycle:
+
+- **Messaging tier.** Acquired on first call to `swarm_getMessagingIdentity`,
+  `swarm_subscribe`, `swarm_sendPss`, or `swarm_sendGsoc`. Separate from the
+  publish and feed tiers. Rationale: messaging discloses a stable per-origin
+  public identity, opens a resource-consuming receive pipeline (the node pulls
+  from a neighborhood on the origin's behalf), and sends consume postage. Any
+  messaging method MAY trigger the grant prompt on first call; on rejection the
+  method MUST reject with `4001`.
+- **Send consent.** `swarm_sendPss`/`swarm_sendGsoc` MAY additionally require
+  per-operation approval (like `swarm_publishData`), or fall under an origin
+  auto-approve the user has enabled. Implementations MUST still enforce size
+  limits and stamp checks under auto-approve.
+- **Subscription resource control.** Subscriptions consume bandwidth for as long
+  as they are open. Implementations MUST cap concurrent subscriptions per origin
+  (`maxSubscriptions`) and SHOULD apply per-origin bandwidth accounting to the
+  receive pipeline, tighter for origins that have not been explicitly granted
+  messaging.
+- **Revocation.** On disconnect/revocation the provider MUST tear down the
+  origin's subscriptions and stop emitting `message` events for it, consistent
+  with the core spec's `disconnect` behavior.
+
+### Encoding
+
+Payloads cross the process/IPC/`postMessage` boundary as in the core spec, so
+inbound payloads in the `message` event are **base64** (`encoding: "base64"`),
+decoded exactly as `swarm_readFeedEntry` results are. Outbound `data` accepts
+`string | Uint8Array | ArrayBuffer` as elsewhere.
+
+## Rationale
+
+### Why a subscription primitive instead of polling helpers?
+
+The core API can already be polled (`swarm_readFeedEntry`, `swarm_readSingleOwnerChunk`).
+Polling is sufficient for asynchronous state and is the right tool for
+authoritative catch-up. It cannot reach interactive latency without pathological
+request rates, and it cannot express PSS's push-only, encrypted, point-to-point
+delivery at all. A subscription is the minimal addition that unlocks the class
+of applications the core API cannot serve.
+
+### Why the EIP-1193 `message`-event shape?
+
+Web3 developers already know `eth_subscribe` → subscription id → `message`
+events. Reusing that shape (with `type: "swarm_subscription"`) means existing
+mental models and tooling transfer, and keeps the provider to a single streaming
+idiom rather than inventing per-method callbacks.
+
+### Why is GSOC send a new method rather than `swarm_writeSingleOwnerChunk`?
+
+The core SOC write signs with the origin's fixed app-scoped identity at a
+caller-chosen identifier. GSOC requires an owner key *mined* so the resulting
+SOC address falls in a chosen neighborhood — a different owner, chosen by the
+provider, not the origin identity. Overloading the core method with a mining
+mode would complicate its clean "sign with your identity" contract; a dedicated
+method keeps both honest.
+
+### Why expose a PSS public key separately from the signing identity?
+
+Receiving PSS requires peers to encrypt to a key the node holds the private half
+of. That key's role (encryption) and possibly its derivation differ from the
+feed/SOC signing key. Exposing it explicitly via `swarm_getMessagingIdentity`
+avoids conflating the two and lets implementations choose their key management.
+
+### Why surface best-effort/unordered/at-least-once so prominently?
+
+Because building on a false reliability assumption is the most likely way to
+misuse this API. Stating the true semantics steers applications toward
+CRDT/idempotent designs (which compose perfectly with these guarantees) and
+toward using the durable feed layer for authoritative state — the intended
+architecture: **feeds for the source of truth, messaging for live propagation.**
+
+## Backwards Compatibility
+
+Purely additive. Implementations without this extension omit the messaging
+methods and the `"messaging"` feature flag; dApps detect absence via
+`swarm_getCapabilities().features` and fall back to the feed/polling approach.
+No core method changes.
+
+## Security Considerations
+
+Inherits the core specification's origin trust model, key-custody rules
+(messaging private keys MUST NOT reach the page context; encryption/signing
+occur in the trusted context), and resource-exhaustion posture. Additional
+considerations:
+
+- **Receive pipeline as an amplification/DoS surface.** A subscription makes the
+  user's node pull from a neighborhood on the origin's behalf. Unbounded
+  subscriptions or very shallow targets could be abused to consume bandwidth.
+  Implementations MUST cap concurrent subscriptions (`maxSubscriptions`) and
+  SHOULD bound per-origin receive bandwidth, with tighter limits for
+  un-granted origins.
+- **Metadata exposure.** PSS hides payloads but the existence and neighborhood
+  of traffic is observable to the network. Subscribing to a topic reveals
+  interest in that neighborhood to peers the node pulls from. Applications
+  handling sensitive relationships SHOULD treat topics as potentially
+  observable and derive them so as not to leak identifiers.
+- **Send is unauthenticated at the transport layer.** GSOC broadcasts can be
+  written by anyone who derives the address; PSS messages can be sent by anyone
+  who knows the recipient key and topic. Applications MUST authenticate message
+  *content* themselves (e.g. signed payloads) and MUST NOT trust a message's
+  origin from the transport alone. This mirrors the core spec's stance that the
+  provider secures access to the node, not the semantics of arbitrary data.
+- **Payload confidentiality.** GSOC payloads are plaintext on Swarm unless the
+  application encrypts them; only PSS provides transport encryption. For a
+  private collaborative session over GSOC, the application MUST encrypt payloads
+  (e.g. with a per-session key shared out of band, as the Freedom Docs
+  capability-link model already does).
+- **Duplicate/stale delivery.** At-least-once, unordered delivery means a
+  malicious or lagging peer could replay old messages. Application-layer
+  sequence/version handling (again, native to CRDTs) is required; state MUST NOT
+  advance irreversibly on receipt of a single unverified message.
+
+## Test Cases
+
+### Feature Detection
+
+```javascript
+const caps = await window.swarm.getCapabilities()
+assert(Array.isArray(caps.features))
+const hasMessaging = caps.features.includes('messaging')
+if (hasMessaging) {
+  assert(typeof caps.limits.maxMessageBytes === 'number')
+  assert(typeof caps.limits.maxSubscriptions === 'number')
+}
+```
+
+### Messaging Identity
+
+```javascript
+const id = await window.swarm.getMessagingIdentity()
+assert(/^[0-9a-f]{66}$/.test(id.pssPublicKey))   // 33-byte compressed key
+assert(/^[0-9a-f]{64}$/.test(id.overlay))
+```
+
+### GSOC Broadcast Round-Trip (two peers, same topic)
+
+```javascript
+// Peer B subscribes
+const sub = await window.swarm.subscribe({ kind: 'gsoc', topic: 'room:doc-42' })
+assert(typeof sub.subscriptionId === 'string')
+assert(/^[0-9a-f]{64}$/.test(sub.key))   // resolved GSOC address
+
+const received = new Promise((resolve) => {
+  window.swarm.on('message', (m) => {
+    if (m.subscription === sub.subscriptionId) {
+      const bytes = Uint8Array.from(atob(m.result.data), c => c.charCodeAt(0))
+      resolve(new TextDecoder().decode(bytes))
+    }
+  })
+})
+
+// Peer A sends on the same topic (address derives identically)
+const sent = await window.swarm.sendGsoc({ topic: 'room:doc-42', data: 'hello room' })
+assert(sent.sent === true)
+assert(sent.address === sub.key)   // deterministic topic→address derivation
+
+assert(await received === 'hello room')
+```
+
+### PSS Point-to-Point
+
+```javascript
+// Recipient publishes its messaging identity out of band
+const me = await window.swarm.getMessagingIdentity()
+const sub = await window.swarm.subscribe({ kind: 'pss', topic: 'dm:alice' })
+
+// Sender (knowing recipient.pssPublicKey and topic)
+await window.swarm.sendPss({
+  topic: 'dm:alice',
+  recipient: recipientPssPublicKey,   // 66-char hex
+  data: 'private hello',
+})
+// recipient's 'message' event fires with kind:'pss', decrypted payload
+```
+
+### Unsubscribe Stops Delivery
+
+```javascript
+const sub = await window.swarm.subscribe({ kind: 'gsoc', topic: 't' })
+const res = await window.swarm.unsubscribe({ subscriptionId: sub.subscriptionId })
+assert(res.unsubscribed === true)
+// No further 'message' events fire for sub.subscriptionId
+
+try {
+  await window.swarm.unsubscribe({ subscriptionId: 'nonexistent' })
+} catch (err) {
+  assert(err.code === -32602)
+  assert(err.data.reason === 'subscription_not_found')
+}
+```
+
+### Payload Too Large
+
+```javascript
+const { maxMessageBytes } = (await window.swarm.getCapabilities()).limits
+try {
+  await window.swarm.sendGsoc({ topic: 't', data: 'x'.repeat(maxMessageBytes + 1) })
+  assert.fail('should reject')
+} catch (err) {
+  assert(err.code === -32602)
+  assert(err.data.reason === 'payload_too_large')
+}
+```
+
+### Permission Gating
+
+```javascript
+// Before the messaging grant, a messaging method prompts; on rejection:
+try {
+  await window.swarm.subscribe({ kind: 'gsoc', topic: 't' })
+  assert.fail('should reject when user denies messaging permission')
+} catch (err) {
+  assert(err.code === 4001)   // User Rejected
+}
+```
+
+## Future Work
+
+- **Mid-stream error signalling.** A normative way to report that an established
+  subscription's pipeline has degraded/failed (a dedicated event or a
+  `message` error variant), rather than the current SHOULD-document approach.
+- **Delivery/ack extensions for PSS.** Optional application-visible send
+  acknowledgement where the underlying primitive can support it.
+- **Presence/awareness helpers.** A higher-level convention for ephemeral
+  presence (cursors, typing) layered on GSOC, if a common pattern emerges.
+- **Backpressure signalling.** Surfacing to the dApp when the provider is
+  shedding inbound messages under load, so applications can adapt send rates.
+
+## Reference Endpoints (informative)
+
+This extension is designed to sit atop light-node PSS/GSOC support exposing
+gateway endpoints equivalent to:
+
+- `POST /pss/send/{topic}/{targets}` (+ recipient key) — backs `swarm_sendPss`
+- `POST /soc/{owner}/{id}` with mined owner/id — backs `swarm_sendGsoc`
+- `GET /gsoc/subscribe/{address}` (streaming) — backs `swarm_subscribe` (gsoc)
+- `GET /pss/subscribe/{topic}` (streaming) — backs `swarm_subscribe` (pss)
+- `GET /addresses` reporting `pssPublicKey`/overlay — backs `swarm_getMessagingIdentity`
+
+The provider is responsible for translating the ergonomic, consent-gated,
+origin-scoped method surface above onto whatever node interface it drives; these
+endpoints are named only to ground the mapping.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/SWIPs/swip-draft_provider_api_messaging.md
+++ b/SWIPs/swip-draft_provider_api_messaging.md
@@ -120,7 +120,7 @@ addition to the core set:
 
 ```javascript
 window.swarm.getMessagingIdentity()                        // swarm_getMessagingIdentity
-window.swarm.subscribe({ kind, topic })                    // swarm_subscribe
+window.swarm.subscribe({ kind, topic, history })           // swarm_subscribe
 window.swarm.unsubscribe({ subscriptionId })               // swarm_unsubscribe
 window.swarm.sendPss({ topic, recipient, targets, data })  // swarm_sendPss
 window.swarm.sendGsoc({ topic, data })                     // swarm_sendGsoc
@@ -173,7 +173,7 @@ following `data.reason` values for `-32602` (Invalid Params):
 | `invalid_topic` | `swarm_subscribe`, `swarm_sendPss`, `swarm_sendGsoc` | Topic is missing or not a valid non-empty string / 64-char hex where hex is required. |
 | `invalid_address` | `swarm_subscribe` | An explicit GSOC `address` is not a valid 64-char hex. |
 | `invalid_recipient` | `swarm_sendPss` | Recipient public key is missing or not a valid 33-byte compressed secp256k1 key (66-char hex). |
-| `invalid_target` | `swarm_sendPss` | `targets` is missing or not valid hex encoding 1–`maxTargetDepth` whole bytes. |
+| `invalid_target` | `swarm_sendPss` | `targets` is missing, not valid hex, or outside 2–`maxTargetDepth` whole bytes (a 1-byte target is too shallow to be stored — see [PSS mining depth](#pss-mining-depth-prefix-length)). |
 | `invalid_kind` | `swarm_subscribe` | `kind` is not `"gsoc"` or `"pss"`. |
 | `payload_too_large` | `swarm_sendPss`, `swarm_sendGsoc` | Payload exceeds `maxMessageBytes`. |
 | `invalid_payload` | `swarm_sendGsoc` | Payload is empty. A GSOC update is a single-owner chunk and bee's chunk layer rejects an empty SOC payload, so an empty broadcast cannot be expressed. (`swarm_sendPss` **does** accept an empty payload — the PSS trojan framing carries an explicit length.) |
@@ -210,7 +210,7 @@ requires consent, mirroring `swarm_getSigningIdentity` in the core spec.
 ```javascript
 {
   pssPublicKey: string,   // 66-char hex, 33-byte compressed secp256k1 public key
-  pssTarget: string,      // hex neighborhood prefix (1–maxTargetDepth bytes); peers pass it as `targets` in swarm_sendPss
+  pssTarget: string,      // hex neighborhood prefix (2..maxTargetDepth bytes); peers pass it as `targets` in swarm_sendPss
   identityMode: string    // "app-scoped" or "bee-wallet" (as in the core spec)
 }
 ```
@@ -228,12 +228,19 @@ the node is unavailable.
   cannot present another's messaging identity.
 - Whether the PSS key is bound to the same key as `swarm_getSigningIdentity`'s
   `owner` is implementation-defined; dApps MUST NOT assume equality.
-- `pssTarget` MUST be a truncated neighborhood prefix of at most
-  `maxTargetDepth` bytes, NOT the node's full overlay address. PSS routing only
-  needs a prefix; the full 64-hex overlay is a node-global value, identical for
-  every origin, that would function as a cross-origin correlation handle and
-  disclose the node's exact network position (see
-  [Security Considerations](#security-considerations)).
+- `pssTarget` MUST be a truncated neighborhood prefix, **at least 2 and at most
+  `maxTargetDepth` bytes**, NOT the node's full overlay address. Two bounds, two
+  reasons:
+  - *Upper* (privacy): the full 64-hex overlay is a node-global value, identical
+    for every origin, that would function as a cross-origin correlation handle
+    and disclose the node's exact network position (see
+    [Security Considerations](#security-considerations)).
+  - *Lower* (deliverability): the prefix length is the number of leading bits a
+    sender's trojan chunk is mined to match, and it must be **deep enough that
+    storers in the neighborhood actually keep the chunk** — a prefix shallower
+    than the network's storage depth produces chunks no reserve retains, so the
+    message is undeliverable. It also governs the receiver's pull cost. See
+    [PSS mining depth](#pss-mining-depth-prefix-length).
 
 ---
 
@@ -249,6 +256,7 @@ Open a long-lived subscription. Incoming messages are delivered via the
 | `kind` | `"gsoc" \| "pss"` | Yes | Subscription type. |
 | `topic` | `string` | Conditional | GSOC: a topic string the provider deterministically maps to a GSOC address. PSS: the topic to receive on. Required unless a raw `address` is given for GSOC. |
 | `address` | `string` | Conditional | GSOC only. A raw 64-char hex GSOC/SOC address, for interoperating with GSOCs whose address was derived elsewhere. Mutually exclusive with `topic`. |
+| `history` | `boolean` | No | PSS only. When `true`, on subscribe the provider attempts to deliver messages that arrived *before* the subscription — a **mailbox** — recovering offline messages, subject to storer retention and an implementation-defined bound (see [Delivery semantics](#delivery-semantics-normative)). Default `false` (live traffic only). Ignored for GSOC (a SOC has a single latest value, not a message backlog). |
 | `options` | `object` | No | Reserved. Unknown fields rejected with `unsupported_option`. |
 
 **Result:**
@@ -322,12 +330,28 @@ permanent refusal.
   addressable by `swarm_unsubscribe`.
 
 **Delivery semantics (normative):** Messages are **best-effort, unordered, and
-at-least-once**. A subscriber MAY miss messages published while it was not
-subscribed, MAY receive messages out of send order, and MAY (across
-resubscription) receive a message more than once. Applications MUST tolerate
-this. Ordering/causality and gap recovery are application concerns; the durable
-Swarm feed layer (core spec) is the appropriate substrate for authoritative
-state and catch-up, with messaging used for live propagation.
+at-least-once**. Without `history`, a subscriber MAY miss messages published
+while it was not subscribed, MAY receive messages out of send order, and MAY
+(across resubscription) receive a message more than once. Applications MUST
+tolerate this. Ordering/causality and gap recovery are application concerns; the
+durable Swarm feed layer (core spec) is the appropriate substrate for
+authoritative state and catch-up, with messaging used for live propagation.
+
+**With `history: true` (mailbox):** on subscribe the provider SHOULD additionally
+deliver messages that arrived before the subscription — offline delivery. This
+is **bounded and best-effort**, not a durable queue: recovery is limited by (a)
+storer **retention** — a message whose postage stamp has expired, or that has
+been evicted from neighborhood reserves, is unrecoverable; and (b) an
+**implementation-defined lookback bound** the provider MAY impose to keep the
+recovery sweep cheap. Recovered messages carry the same `message`-event shape as
+live ones and are subject to the same at-least-once/may-duplicate guarantees;
+`receivedAt` reflects when the *provider* recovered the message, not when it was
+originally sent (a sender-supplied timestamp, if wanted, is application payload).
+Whether historical messages are ordered relative to each other is
+implementation-defined; applications needing send-order MUST carry their own
+sequence. The recoverable depth scales with the mining prefix length (see
+[PSS mining depth](#pss-mining-depth-prefix-length)): a deeper prefix makes the
+whole neighborhood backlog small enough to sweep completely.
 
 ---
 
@@ -375,7 +399,7 @@ consumes a postage stamp).
 |---|---|---|---|
 | `topic` | `string` | Yes | Topic the recipient subscribes on. Hashed/normalized by the provider as in Bee PSS. |
 | `recipient` | `string` | Yes | Recipient PSS public key: 66-char hex, 33-byte compressed secp256k1 (as returned by `swarm_getMessagingIdentity`). |
-| `targets` | `string` | Yes | Neighborhood prefix as hex (1–`maxTargetDepth` bytes) locating the recipient — the value the recipient's `swarm_getMessagingIdentity` returned as `pssTarget`, shared out of band alongside their public key. The sender's provider cannot derive this from the public key alone. Deeper targets = more precise routing, higher cost. |
+| `targets` | `string` | Yes | Neighborhood prefix as hex (**2**–`maxTargetDepth` bytes) locating the recipient — the value the recipient's `swarm_getMessagingIdentity` returned as `pssTarget`, shared out of band alongside their public key. The sender's provider cannot derive this from the public key alone. The prefix length sets the trojan's mining depth (see [PSS mining depth](#pss-mining-depth-prefix-length)): it MUST be deep enough that neighborhood storers keep the chunk, and deeper targets cost more to mine but less to receive. |
 | `data` | `string \| Uint8Array \| ArrayBuffer` | Yes | Payload. Strings encoded UTF-8. MUST be ≤ `maxMessageBytes`. MAY be empty — the PSS trojan framing carries an explicit length, so a zero-byte message is well-formed (useful for pings/signals). |
 | `options` | `object` | No | Reserved. Unknown fields rejected with `unsupported_option`. |
 
@@ -402,7 +426,50 @@ connected. `4900` if node unavailable or no usable postage stamp. `-32602` for
 
 ---
 
-#### `swarm_sendGsoc`
+### PSS mining depth (prefix length)
+
+A PSS message is a *trojan chunk* whose content-address is **mined** to share a
+number of leading bits — the **prefix length**, `L` bits = `targets`/`pssTarget`
+byte-count × 8 — with the recipient's overlay, so the network routes it into the
+recipient's neighborhood. `L` is not a free knob; it is bounded on both sides,
+which is why this spec constrains `targets`/`pssTarget` to **2–`maxTargetDepth`
+bytes** rather than the underlying primitive's 1-byte floor.
+
+**Lower bound — storability.** Neighborhood storers keep a chunk only if it falls
+within their storage depth `d` (the proximity order at which the reserve is
+maintained). A trojan mined to `L < d` lands *outside* every neighborhood
+storer's reserve and is simply not stored — the send returns success (the chunk
+was accepted for upload) but no one retains it, so it is undeliverable. On the
+public network `d` is on the order of a dozen bits and rises with network growth;
+a 1-byte (`L=8`) target is below it, which is why 1-byte targets are rejected. A
+2-byte (`L=16`) target is the current de-facto floor; a 3-byte (`L=24`) target is
+comfortably above `d` with headroom for growth.
+
+**Upper bound — mining cost.** Mining is ~`2^L` hashes, so `maxTargetDepth`
+(typically 3 bytes) caps sender work.
+
+**Why the receiver cares — reception cost, and the mailbox.** A light-node
+receiver pulls candidate chunks from the neighborhood and tries to decrypt them.
+The volume it must sift is governed by `L`: on a depth-`d` storer the chunks at
+proximity `≥ L` number roughly `2^(reserve_bits − (L − d))` of the reserve, so
+each extra bit of `L` **halves** the receiver's candidate traffic. At `L=16,
+d≈12` that is a sizeable fraction of ingest; at `L=24` it is only ~1–2K chunks —
+small enough that a receiver can sweep the neighborhood's **entire** trojan
+backlog on subscribe, which is exactly what makes the `history` mailbox
+(above) recover *all* offline messages rather than only recent ones. Deeper
+targets thus cost the sender more to mine but make the receiver dramatically
+cheaper and unlock complete offline delivery.
+
+**Convention.** Implementations MUST reject `targets`/`pssTarget` shorter than 2
+bytes (`invalid_target`) and SHOULD document the mining prefix they use.
+Interoperating sender and receiver implementations MUST agree on `L`: a receiver
+pulls the bins a message at prefix `L` can occupy, so a sender mining to a
+different `L` may land where the receiver is not looking. This SWIP does not yet
+pin a single normative `L` — 2 bytes maximizes compatibility with today's
+senders, 3 bytes is materially better for receiver cost and offline delivery —
+and flags it as an open question for the Swarm community (it is arguably a
+network-wide parameter that belongs alongside the storage-depth conventions in
+the core protocol docs, not only in this provider spec).
 
 Broadcast a message on a topic. Any origin subscribed (via `swarm_subscribe`
 with `kind: "gsoc"`) to the address the topic derives to receives it.
@@ -467,7 +534,7 @@ connected. `4900` if node unavailable or no usable postage stamp. `-32602` for
 | Limit | Recommended Default | Notes |
 |---|---|---|
 | `maxMessageBytes` | 3584 | Max PSS/GSOC payload. A Swarm chunk is 4096 bytes; PSS/GSOC framing and encryption overhead reduce the usable payload. Implementations MUST advertise the true usable maximum. |
-| `maxTargetDepth` | 3 | Max neighborhood-prefix length in bytes for PSS `targets`. |
+| `maxTargetDepth` | 3 | Max neighborhood-prefix length in bytes for PSS `targets`/`pssTarget`. The minimum is fixed at **2 bytes** (below the network storage depth chunks are not retained — see [PSS mining depth](#pss-mining-depth-prefix-length)); this limit caps the deep end (sender mining cost). |
 | `maxSubscriptions` | 32 | Max concurrent active subscriptions **per origin**. The node additionally bounds its *aggregate* receive pipelines across all origins (implementation-defined; not advertised here because it is shared state, not a per-origin promise) — exhaustion of that pool surfaces as a retryable `4900`, see `swarm_subscribe`. |
 
 Applications needing to move more than `maxMessageBytes` in one logical message
@@ -680,6 +747,24 @@ await window.swarm.sendPss({
   data: 'private hello',
 })
 // recipient's 'message' event fires with kind:'pss', decrypted payload
+```
+
+### Mailbox (offline delivery)
+
+```javascript
+// A sender posts to a room while nobody is subscribed.
+await window.swarm.sendPss({ topic: 'room:42', recipient, targets, data: 'sent while you were away' })
+
+// Later, a client subscribes WITH history — and receives the earlier message.
+const seen = []
+window.swarm.on('message', (m) => { if (m.subscription === sub.subscriptionId) seen.push(m.result.data) })
+const sub = await window.swarm.subscribe({ kind: 'pss', topic: 'room:42', history: true })
+// `seen` includes messages sent before this subscription existed
+// (bounded by storer retention; see Delivery semantics).
+
+// Without history, the same subscribe would only receive messages sent
+// from now on:
+const liveOnly = await window.swarm.subscribe({ kind: 'pss', topic: 'room:42' })
 ```
 
 ### Unsubscribe Stops Delivery

--- a/SWIPs/swip-draft_provider_api_messaging.md
+++ b/SWIPs/swip-draft_provider_api_messaging.md
@@ -299,7 +299,10 @@ permanent refusal.
   a normative derivation profile exists (see [Future Work](#future-work)),
   applications interoperating across different providers MUST exchange the
   resolved GSOC `address` (returned by both `swarm_subscribe` and
-  `swarm_sendGsoc`) out of band and use the raw `address` parameter.
+  `swarm_sendGsoc`) out of band and use the raw `address` parameter — for
+  **receiving only**. Sending requires the mined owner key, which only the
+  topic derivation yields, so cross-provider *senders* must share the topic
+  itself (see `swarm_sendGsoc` Behavior).
 - For PSS, only messages the node can decrypt (encrypted to this origin's PSS
   key) are delivered. Undecryptable traffic in the neighborhood MUST NOT be
   delivered.
@@ -410,8 +413,7 @@ Operates under the **messaging send tier**.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `topic` | `string` | Conditional | Topic the provider deterministically maps to a GSOC address (same derivation as `swarm_subscribe`). Required unless `address` is given. |
-| `address` | `string` | Conditional | Raw 64-char hex GSOC address. Mutually exclusive with `topic`. |
+| `topic` | `string` | Yes | Topic the provider deterministically maps to a GSOC address (same derivation as `swarm_subscribe`). Unlike `swarm_subscribe`, there is no raw `address` alternative — see Behavior. |
 | `data` | `string \| Uint8Array \| ArrayBuffer` | Yes | Payload. Strings encoded UTF-8. MUST be **1**..`maxMessageBytes` bytes: an empty payload is rejected with `invalid_payload` (a GSOC update is a single-owner chunk, and bee's chunk layer refuses an empty SOC payload — the provider must not sign a chunk the network will not accept). |
 | `options` | `object` | No | Reserved. Unknown fields rejected with `unsupported_option`. |
 
@@ -426,13 +428,22 @@ Operates under the **messaging send tier**.
 
 **Errors:** `4001` if the user rejects a per-send prompt. `4100` if not
 connected. `4900` if node unavailable or no usable postage stamp. `-32602` for
-`invalid_topic`, `invalid_address`, `invalid_payload`, `payload_too_large`,
-`unsupported_option`.
+`invalid_topic`, `invalid_payload`, `payload_too_large`, `unsupported_option`.
 
 **Behavior:**
 - GSOC send writes a Single Owner Chunk at the derived address. The provider
   performs any required owner mining so the chunk lands in the correct
   neighborhood, signs it, and uploads it with an automatically-selected batch.
+- **There is deliberately no raw `address` variant** (asymmetric with
+  `swarm_subscribe`, which accepts one). Writing a GSOC requires signing with
+  the mined owner key, and that key is recovered by re-running the derivation
+  from the topic; a GSOC address is a hash output
+  (`keccak256(identifier ‖ owner)`) from which neither the identifier nor the
+  owner key can be recovered. An address alone therefore carries nothing to
+  sign with — watching an address is passive, authoring at one is not. Senders
+  interoperating across providers MUST share the topic (and, until a normative
+  derivation profile exists, use the same provider implementation or agree on
+  the derivation out of band).
 - Re-sending on the same topic overwrites the SOC at that address with a newer
   timestamp (this is how a broadcast channel advances). Because delivery is
   at-least-once and unordered, subscribers MUST NOT assume they observe every
@@ -522,6 +533,18 @@ SOC address falls in a chosen neighborhood — a different owner, chosen by the
 provider, not the origin identity. Overloading the core method with a mining
 mode would complicate its clean "sign with your identity" contract; a dedicated
 method keeps both honest.
+
+### Why does `swarm_sendGsoc` accept a topic but not an address?
+
+An earlier draft mirrored `swarm_subscribe` and allowed a raw `address` on
+send. That was unimplementable: authoring a GSOC means producing a signature
+from the mined owner key, and the address — `keccak256(identifier ‖ owner)` —
+is a one-way hash of the very material a sender needs. Every conforming
+provider would have had to reject the parameter at runtime; better for the
+interface to make the impossible state unrepresentable. The asymmetry is
+principled: subscribing to an address is passive observation, sending to one
+is authorship, and authorship needs the key that only the topic derivation
+(or out-of-band agreement on it) can reproduce.
 
 ### Why expose a PSS public key separately from the signing identity?
 

--- a/SWIPs/swip-draft_provider_api_messaging.md
+++ b/SWIPs/swip-draft_provider_api_messaging.md
@@ -176,6 +176,7 @@ following `data.reason` values for `-32602` (Invalid Params):
 | `invalid_target` | `swarm_sendPss` | `targets` is missing or not valid hex encoding 1–`maxTargetDepth` whole bytes. |
 | `invalid_kind` | `swarm_subscribe` | `kind` is not `"gsoc"` or `"pss"`. |
 | `payload_too_large` | `swarm_sendPss`, `swarm_sendGsoc` | Payload exceeds `maxMessageBytes`. |
+| `invalid_payload` | `swarm_sendGsoc` | Payload is empty. A GSOC update is a single-owner chunk and bee's chunk layer rejects an empty SOC payload, so an empty broadcast cannot be expressed. (`swarm_sendPss` **does** accept an empty payload — the PSS trojan framing carries an explicit length.) |
 | `subscription_not_found` | `swarm_unsubscribe` | No active subscription with the given id for this origin. |
 | `too_many_subscriptions` | `swarm_subscribe` | The origin has reached `maxSubscriptions`. |
 | `unsupported_option` | messaging methods accepting `options` | An unrecognized option field was supplied. |
@@ -262,9 +263,24 @@ Open a long-lived subscription. Incoming messages are delivered via the
 
 **Errors:** `4001` if the user rejects the messaging-permission prompt this call
 triggered. `4100` if the origin lacks basic connection or a prompt cannot be
-surfaced. `4900` if the node is unavailable. `-32602` for
+surfaced. `4900` if the node is unavailable, **or if the node's aggregate
+subscription capacity is exhausted** (see below). `-32602` for
 `invalid_kind`, `invalid_topic`, `invalid_address`, `too_many_subscriptions`,
 `unsupported_option`.
+
+**Per-origin cap vs. node capacity — two distinct failures.**
+`too_many_subscriptions` (`-32602`) means *this origin* has reached
+`maxSubscriptions`: the dApp caused it and can fix it by unsubscribing. But a
+receive pipeline is a **node-wide** resource — an implementation typically
+bounds the number of *distinct neighborhoods* it will pull concurrently across
+**all** origins (the reference light-node implementation allows 8), and that
+pool can be exhausted by *other* origins' subscriptions. That case MUST be
+reported as `4900` with a message naming subscription capacity, NOT as
+`too_many_subscriptions`: it is not a parameter error, the calling dApp did
+nothing wrong, and it is **retryable** — capacity frees when other
+subscriptions close. DApps SHOULD treat it like any other transient node
+condition (back off and retry, or degrade to feed polling) rather than as a
+permanent refusal.
 
 **Behavior:**
 - Subscribing establishes a receive pipeline for the target neighborhood. The
@@ -357,7 +373,7 @@ consumes a postage stamp).
 | `topic` | `string` | Yes | Topic the recipient subscribes on. Hashed/normalized by the provider as in Bee PSS. |
 | `recipient` | `string` | Yes | Recipient PSS public key: 66-char hex, 33-byte compressed secp256k1 (as returned by `swarm_getMessagingIdentity`). |
 | `targets` | `string` | Yes | Neighborhood prefix as hex (1–`maxTargetDepth` bytes) locating the recipient — the value the recipient's `swarm_getMessagingIdentity` returned as `pssTarget`, shared out of band alongside their public key. The sender's provider cannot derive this from the public key alone. Deeper targets = more precise routing, higher cost. |
-| `data` | `string \| Uint8Array \| ArrayBuffer` | Yes | Payload. Strings encoded UTF-8. MUST be ≤ `maxMessageBytes`. |
+| `data` | `string \| Uint8Array \| ArrayBuffer` | Yes | Payload. Strings encoded UTF-8. MUST be ≤ `maxMessageBytes`. MAY be empty — the PSS trojan framing carries an explicit length, so a zero-byte message is well-formed (useful for pings/signals). |
 | `options` | `object` | No | Reserved. Unknown fields rejected with `unsupported_option`. |
 
 **Result:**
@@ -396,7 +412,7 @@ Operates under the **messaging send tier**.
 |---|---|---|---|
 | `topic` | `string` | Conditional | Topic the provider deterministically maps to a GSOC address (same derivation as `swarm_subscribe`). Required unless `address` is given. |
 | `address` | `string` | Conditional | Raw 64-char hex GSOC address. Mutually exclusive with `topic`. |
-| `data` | `string \| Uint8Array \| ArrayBuffer` | Yes | Payload. Strings encoded UTF-8. MUST be ≤ `maxMessageBytes`. |
+| `data` | `string \| Uint8Array \| ArrayBuffer` | Yes | Payload. Strings encoded UTF-8. MUST be **1**..`maxMessageBytes` bytes: an empty payload is rejected with `invalid_payload` (a GSOC update is a single-owner chunk, and bee's chunk layer refuses an empty SOC payload — the provider must not sign a chunk the network will not accept). |
 | `options` | `object` | No | Reserved. Unknown fields rejected with `unsupported_option`. |
 
 **Result:**
@@ -410,7 +426,8 @@ Operates under the **messaging send tier**.
 
 **Errors:** `4001` if the user rejects a per-send prompt. `4100` if not
 connected. `4900` if node unavailable or no usable postage stamp. `-32602` for
-`invalid_topic`, `invalid_address`, `payload_too_large`, `unsupported_option`.
+`invalid_topic`, `invalid_address`, `invalid_payload`, `payload_too_large`,
+`unsupported_option`.
 
 **Behavior:**
 - GSOC send writes a Single Owner Chunk at the derived address. The provider
@@ -440,7 +457,7 @@ connected. `4900` if node unavailable or no usable postage stamp. `-32602` for
 |---|---|---|
 | `maxMessageBytes` | 3584 | Max PSS/GSOC payload. A Swarm chunk is 4096 bytes; PSS/GSOC framing and encryption overhead reduce the usable payload. Implementations MUST advertise the true usable maximum. |
 | `maxTargetDepth` | 3 | Max neighborhood-prefix length in bytes for PSS `targets`. |
-| `maxSubscriptions` | 32 | Max concurrent active subscriptions per origin. |
+| `maxSubscriptions` | 32 | Max concurrent active subscriptions **per origin**. The node additionally bounds its *aggregate* receive pipelines across all origins (implementation-defined; not advertised here because it is shared state, not a per-origin promise) — exhaustion of that pool surfaces as a retryable `4900`, see `swarm_subscribe`. |
 
 Applications needing to move more than `maxMessageBytes` in one logical message
 MUST chunk at the application layer, or publish the bulk via `swarm_publishData`
@@ -669,6 +686,24 @@ try {
   assert(err.code === -32602)
   assert(err.data.reason === 'payload_too_large')
 }
+```
+
+### Payload Bounds (empty)
+
+```javascript
+// GSOC cannot express an empty broadcast (bee rejects an empty SOC payload):
+try {
+  await window.swarm.sendGsoc({ topic: 't', data: '' })
+  assert.fail('should reject')
+} catch (err) {
+  assert(err.code === -32602)
+  assert(err.data.reason === 'invalid_payload')
+}
+// PSS carries an explicit length, so a zero-byte message is valid:
+const res = await window.swarm.sendPss({
+  topic: 't', recipient: peerKey, targets: peerTarget, data: '',
+})
+assert(res.sent === true)
 ```
 
 ### Permission Gating

--- a/SWIPs/swip-draft_provider_api_messaging.md
+++ b/SWIPs/swip-draft_provider_api_messaging.md
@@ -39,7 +39,7 @@ This extension adds that channel. It specifies:
 - **`swarm_sendGsoc`** — broadcast a message on a topic that any subscriber to
   the derived GSOC address receives.
 - **`swarm_getMessagingIdentity`** — disclose this origin's PSS public key and
-  overlay, so peers can address messages to it.
+  routing target, so peers can address messages to it.
 
 PSS and GSOC are existing Swarm/Bee primitives; this extension does not define
 them, only their exposure at the provider boundary with consent and
@@ -109,8 +109,9 @@ if (caps.features?.includes('messaging')) {
 ```
 
 `swarm_getCapabilities` is additionally extended with messaging limits (see
-[Limits](#limits)). Both `features` and the new limit fields MAY be returned
-before `swarm_requestAccess` (they are static capability facts).
+[Limits](#limits)). Both `features` and the new limit fields MUST be available
+before `swarm_requestAccess` — the core spec makes `swarm_getCapabilities`
+permission-free, and these are static capability facts, not user data.
 
 ### Convenience Methods
 
@@ -121,7 +122,7 @@ addition to the core set:
 window.swarm.getMessagingIdentity()                        // swarm_getMessagingIdentity
 window.swarm.subscribe({ kind, topic })                    // swarm_subscribe
 window.swarm.unsubscribe({ subscriptionId })               // swarm_unsubscribe
-window.swarm.sendPss({ topic, recipient, data })           // swarm_sendPss
+window.swarm.sendPss({ topic, recipient, targets, data })  // swarm_sendPss
 window.swarm.sendGsoc({ topic, data })                     // swarm_sendGsoc
 ```
 
@@ -172,6 +173,7 @@ following `data.reason` values for `-32602` (Invalid Params):
 | `invalid_topic` | `swarm_subscribe`, `swarm_sendPss`, `swarm_sendGsoc` | Topic is missing or not a valid non-empty string / 64-char hex where hex is required. |
 | `invalid_address` | `swarm_subscribe` | An explicit GSOC `address` is not a valid 64-char hex. |
 | `invalid_recipient` | `swarm_sendPss` | Recipient public key is missing or not a valid 33-byte compressed secp256k1 key (66-char hex). |
+| `invalid_target` | `swarm_sendPss` | `targets` is missing or not valid hex encoding 1–`maxTargetDepth` whole bytes. |
 | `invalid_kind` | `swarm_subscribe` | `kind` is not `"gsoc"` or `"pss"`. |
 | `payload_too_large` | `swarm_sendPss`, `swarm_sendGsoc` | Payload exceeds `maxMessageBytes`. |
 | `subscription_not_found` | `swarm_unsubscribe` | No active subscription with the given id for this origin. |
@@ -179,11 +181,13 @@ following `data.reason` values for `-32602` (Invalid Params):
 | `unsupported_option` | messaging methods accepting `options` | An unrecognized option field was supplied. |
 
 A subscription whose underlying receive pipeline fails after being established
-(e.g. the node loses connectivity) MUST NOT silently stop. The provider SHOULD
-emit a `message` with a transport-level error indicator OR emit `disconnect`
-semantics per the core spec; at minimum, implementations MUST document their
-failure signalling. (Normative signalling of mid-stream subscription errors is
-deferred to a future revision; see [Future Work](#future-work).)
+(e.g. the node loses connectivity) has no per-subscription error signal in this
+revision — the `SubscriptionMessage` schema deliberately has no error variant,
+and normative mid-stream error signalling is deferred to a future revision (see
+[Future Work](#future-work)). Where the failure is node-wide, the core spec's
+`disconnect` event already applies. Implementations MUST document how a
+degraded or failed pipeline behaves (silent gap until recovery, automatic
+teardown, etc.) so applications can reason about liveness.
 
 ---
 
@@ -192,7 +196,7 @@ deferred to a future revision; see [Future Work](#future-work).)
 #### `swarm_getMessagingIdentity`
 
 Return this origin's messaging identity — the PSS public key peers encrypt to,
-and the node overlay used for neighborhood targeting.
+and the neighborhood-prefix target peers route toward when sending to it.
 
 Operates under the **messaging permission tier** (see [Permission Model](#permission-model)):
 the returned public key is a stable per-origin identifier, so disclosure
@@ -205,7 +209,7 @@ requires consent, mirroring `swarm_getSigningIdentity` in the core spec.
 ```javascript
 {
   pssPublicKey: string,   // 66-char hex, 33-byte compressed secp256k1 public key
-  overlay: string,        // 64-char hex node overlay address (neighborhood targeting)
+  pssTarget: string,      // hex neighborhood prefix (1–maxTargetDepth bytes); peers pass it as `targets` in swarm_sendPss
   identityMode: string    // "app-scoped" or "bee-wallet" (as in the core spec)
 }
 ```
@@ -223,6 +227,12 @@ the node is unavailable.
   cannot present another's messaging identity.
 - Whether the PSS key is bound to the same key as `swarm_getSigningIdentity`'s
   `owner` is implementation-defined; dApps MUST NOT assume equality.
+- `pssTarget` MUST be a truncated neighborhood prefix of at most
+  `maxTargetDepth` bytes, NOT the node's full overlay address. PSS routing only
+  needs a prefix; the full 64-hex overlay is a node-global value, identical for
+  every origin, that would function as a cross-origin correlation handle and
+  disclose the node's exact network position (see
+  [Security Considerations](#security-considerations)).
 
 ---
 
@@ -260,16 +270,30 @@ surfaced. `4900` if the node is unavailable. `-32602` for
 - Subscribing establishes a receive pipeline for the target neighborhood. The
   implementation is responsible for pulling and decrypting matching chunks and
   delivering decoded payloads via the `message` event.
-- **GSOC topic → address derivation MUST be deterministic** so that independent
-  parties passing the same `topic` subscribe to and send at the same address.
-  The derivation MUST be documented by the implementation and SHOULD match
-  bee-js `gsocMine` semantics for cross-implementation interop.
+- **GSOC topic → address derivation MUST be deterministic within an
+  implementation**: any two origins passing the same `topic` to the same
+  provider MUST resolve to the same address, whether subscribing or sending.
+  The derivation MUST be documented by the implementation.
+- **Cross-implementation convergence is NOT guaranteed in this revision.**
+  Determinism alone does not pin the address: implementations must additionally
+  agree on the identifier derivation (topic → 32-byte SOC identifier), the
+  target-neighborhood derivation (topic → overlay prefix), the mining algorithm
+  and its search order (e.g. bee-js `gsocMine`), and the required proximity —
+  a difference in any one yields a different address for the same topic. Until
+  a normative derivation profile exists (see [Future Work](#future-work)),
+  applications interoperating across different providers MUST exchange the
+  resolved GSOC `address` (returned by both `swarm_subscribe` and
+  `swarm_sendGsoc`) out of band and use the raw `address` parameter.
 - For PSS, only messages the node can decrypt (encrypted to this origin's PSS
   key) are delivered. Undecryptable traffic in the neighborhood MUST NOT be
   delivered.
 - The provider MUST deduplicate deliveries; the same message MUST NOT be
   delivered twice for one subscription. (Across a resubscribe, redelivery is
-  permitted — see delivery semantics.)
+  permitted — see delivery semantics.) Note that two *sends* with
+  byte-identical payloads on the same key are indistinguishable at the
+  transport layer and MAY therefore be coalesced into a single delivery;
+  applications that need repeated identical messages observed individually
+  MUST make payloads distinct (e.g. include a sequence number or nonce).
 - Subscriptions are **origin-scoped** and **session-scoped**. They MUST be torn
   down automatically when the page unloads (`pagehide`) and when access is
   revoked (`disconnect`). Implementations are NOT REQUIRED to persist
@@ -332,7 +356,7 @@ consumes a postage stamp).
 |---|---|---|---|
 | `topic` | `string` | Yes | Topic the recipient subscribes on. Hashed/normalized by the provider as in Bee PSS. |
 | `recipient` | `string` | Yes | Recipient PSS public key: 66-char hex, 33-byte compressed secp256k1 (as returned by `swarm_getMessagingIdentity`). |
-| `targets` | `string` | No | Neighborhood prefix as hex (1–`maxTargetDepth` bytes). If omitted, the provider derives targeting from the recipient/overlay. Deeper targets = more precise routing, higher cost. |
+| `targets` | `string` | Yes | Neighborhood prefix as hex (1–`maxTargetDepth` bytes) locating the recipient — the value the recipient's `swarm_getMessagingIdentity` returned as `pssTarget`, shared out of band alongside their public key. The sender's provider cannot derive this from the public key alone. Deeper targets = more precise routing, higher cost. |
 | `data` | `string \| Uint8Array \| ArrayBuffer` | Yes | Payload. Strings encoded UTF-8. MUST be ≤ `maxMessageBytes`. |
 | `options` | `object` | No | Reserved. Unknown fields rejected with `unsupported_option`. |
 
@@ -436,7 +460,9 @@ This extension adds one tier to the core permission lifecycle:
 - **Send consent.** `swarm_sendPss`/`swarm_sendGsoc` MAY additionally require
   per-operation approval (like `swarm_publishData`), or fall under an origin
   auto-approve the user has enabled. Implementations MUST still enforce size
-  limits and stamp checks under auto-approve.
+  limits and stamp checks under auto-approve, and SHOULD additionally apply a
+  per-origin send rate cap there — messaging sends are cheap to issue in a
+  loop and each consumes postage.
 - **Subscription resource control.** Subscriptions consume bandwidth for as long
   as they are open. Implementations MUST cap concurrent subscriptions per origin
   (`maxSubscriptions`) and SHOULD apply per-origin bandwidth accounting to the
@@ -515,6 +541,17 @@ considerations:
   Implementations MUST cap concurrent subscriptions (`maxSubscriptions`) and
   SHOULD bound per-origin receive bandwidth, with tighter limits for
   un-granted origins.
+- **Cross-origin identity correlation.** `pssPublicKey` is per-origin under
+  `app-scoped` derivation, but any node-global value returned to multiple
+  origins is a correlation handle. This is why `swarm_getMessagingIdentity`
+  returns a truncated `pssTarget` prefix rather than the node's full overlay
+  address: the full overlay is identical for every origin, uniquely identifies
+  the user's node, and discloses its exact network position. Even the
+  truncated prefix leaks up to `maxTargetDepth` bytes of neighborhood
+  information and is the same across origins; implementations SHOULD keep
+  `maxTargetDepth` small. Under `bee-wallet` mode the public key itself is
+  node-global; users selecting it accept cross-origin linkability, as in the
+  core spec.
 - **Metadata exposure.** PSS hides payloads but the existence and neighborhood
   of traffic is observable to the network. Subscribing to a topic reveals
   interest in that neighborhood to peers the node pulls from. Applications
@@ -553,12 +590,15 @@ if (hasMessaging) {
 ### Messaging Identity
 
 ```javascript
+const { maxTargetDepth } = (await window.swarm.getCapabilities()).limits
 const id = await window.swarm.getMessagingIdentity()
 assert(/^[0-9a-f]{66}$/.test(id.pssPublicKey))   // 33-byte compressed key
-assert(/^[0-9a-f]{64}$/.test(id.overlay))
+assert(/^([0-9a-f]{2})+$/.test(id.pssTarget))    // whole bytes, hex
+assert(id.pssTarget.length / 2 <= maxTargetDepth) // truncated prefix, never the full overlay
+assert(['app-scoped', 'bee-wallet'].includes(id.identityMode))
 ```
 
-### GSOC Broadcast Round-Trip (two peers, same topic)
+### GSOC Broadcast Round-Trip (two peers, same topic, same provider implementation)
 
 ```javascript
 // Peer B subscribes
@@ -578,7 +618,8 @@ const received = new Promise((resolve) => {
 // Peer A sends on the same topic (address derives identically)
 const sent = await window.swarm.sendGsoc({ topic: 'room:doc-42', data: 'hello room' })
 assert(sent.sent === true)
-assert(sent.address === sub.key)   // deterministic topic→address derivation
+assert(sent.address === sub.key)   // same-provider topic→address determinism
+                                   // (across different providers, exchange `address` instead)
 
 assert(await received === 'hello room')
 ```
@@ -590,10 +631,12 @@ assert(await received === 'hello room')
 const me = await window.swarm.getMessagingIdentity()
 const sub = await window.swarm.subscribe({ kind: 'pss', topic: 'dm:alice' })
 
-// Sender (knowing recipient.pssPublicKey and topic)
+// Sender (knowing the recipient's pssPublicKey, pssTarget, and topic,
+// shared out of band)
 await window.swarm.sendPss({
   topic: 'dm:alice',
   recipient: recipientPssPublicKey,   // 66-char hex
+  targets: recipientPssTarget,        // recipient's getMessagingIdentity().pssTarget
   data: 'private hello',
 })
 // recipient's 'message' event fires with kind:'pss', decrypted payload
@@ -642,6 +685,11 @@ try {
 
 ## Future Work
 
+- **Normative GSOC derivation profile.** A pinned topic → (identifier,
+  target neighborhood, proximity) derivation plus mining algorithm and search
+  order, so the same topic converges on the same address across *independent*
+  provider implementations, not only within one. Until then, cross-provider
+  interop goes through the raw `address` parameter.
 - **Mid-stream error signalling.** A normative way to report that an established
   subscription's pipeline has degraded/failed (a dedicated event or a
   `message` error variant), rather than the current SHOULD-document approach.
@@ -662,6 +710,8 @@ gateway endpoints equivalent to:
 - `GET /gsoc/subscribe/{address}` (streaming) — backs `swarm_subscribe` (gsoc)
 - `GET /pss/subscribe/{topic}` (streaming) — backs `swarm_subscribe` (pss)
 - `GET /addresses` reporting `pssPublicKey`/overlay — backs `swarm_getMessagingIdentity`
+  (the provider truncates the overlay to the `pssTarget` prefix; the full
+  overlay never crosses the page boundary)
 
 The provider is responsible for translating the ergonomic, consent-gated,
 origin-scoped method surface above onto whatever node interface it drives; these

--- a/SWIPs/swip-draft_provider_api_messaging.md
+++ b/SWIPs/swip-draft_provider_api_messaging.md
@@ -349,11 +349,13 @@ live ones and are subject to the same at-least-once/may-duplicate guarantees;
 originally sent (a sender-supplied timestamp, if wanted, is application payload).
 Whether historical messages are ordered relative to each other is
 implementation-defined; applications needing send-order MUST carry their own
-sequence. The recoverable depth scales with the mining prefix length (see
-[PSS mining depth](#pss-mining-depth-prefix-length)): at the adopted `L = 24`
-convention the whole neighborhood backlog is small enough (~1–2K chunks) to
-sweep completely, so the mailbox recovers *all* retained offline messages, not
-just a recent window.
+sequence. How far back the mailbox reaches is implementation-defined and, at the
+default 2-byte prefix, is a **recent-history window** rather than the complete
+backlog (a light-node receiver sweeps a busy neighborhood bin, so a bounded
+lookback covers minutes-to-hours, not all of history). A complete backlog sweep
+would require the trojan concentrated into a sparse deep bin pulled by a
+deeply-resident receiver (see [PSS mining depth](#pss-mining-depth-prefix-length)
+for why that trade is not the default).
 
 ---
 
@@ -444,52 +446,61 @@ storer's reserve and is simply not stored — the send returns success (the chun
 was accepted for upload) but no one retains it, so it is undeliverable. On the
 public network `d` is on the order of a dozen bits and rises with network growth;
 a 1-byte (`L=8`) target is below it, which is why 1-byte targets are rejected. A
-2-byte (`L=16`) target is the current de-facto floor; a 3-byte (`L=24`) target is
-comfortably above `d` with headroom for growth.
+2-byte (`L=16`) target is comfortably above `d` today and is the adopted default.
 
-**Upper bound — mining cost.** Mining is ~`2^L` hashes, so `maxTargetDepth`
-(typically 3 bytes) caps sender work.
+**Upper bound — mining cost.** Mining is `~2^L` hashes, so each extra byte is
+~256× the sender work: a 2-byte mine is sub-second, a 3-byte mine is seconds on a
+constrained (mobile) sender and can exceed a send timeout. `maxTargetDepth` caps
+the deep end.
 
-**Why the receiver cares — reception cost, and the mailbox.** A light-node
-receiver pulls candidate chunks from the neighborhood and tries to decrypt them.
-The volume it must sift is governed by `L`: on a depth-`d` storer the chunks at
-proximity `≥ L` number roughly `2^(reserve_bits − (L − d))` of the reserve, so
-each extra bit of `L` **halves** the receiver's candidate traffic. At `L=16,
-d≈12` that is a sizeable fraction of ingest; at `L=24` it is only ~1–2K chunks —
-small enough that a receiver can sweep the neighborhood's **entire** trojan
-backlog on subscribe, which is exactly what makes the `history` mailbox
-(above) recover *all* offline messages rather than only recent ones. Deeper
-targets thus cost the sender more to mine but make the receiver dramatically
-cheaper and unlock complete offline delivery.
+**Reception cost — and why deeper does not help a light node.** A receiver pulls
+candidate chunks from the covering peers nearest the target and tries to decrypt
+them. It is tempting to think a deeper `L` cuts this: on a depth-`d` storer the
+chunks at proximity `≥ L` number roughly `2^(reserve_bits − (L − d))`, so
+concentrating the trojan deeper shrinks that set. But a receiver only realizes
+that if it pulls the deep bin — which requires a covering peer at proximity
+`≥ L`, i.e. the receiver itself being **deeply resident** in the target
+neighborhood. A light node's covering peers sit shallower than `L`, so it pulls
+the *same* bins and downloads the *same* candidates regardless of `L` — measured
+identical at `L=16` and `L=24` on a reference light node. For the light-node
+deployments this extension targets, a deeper prefix therefore adds sender cost
+without reducing reception cost, and the mailbox is a recent-history window at
+any `L`. (A deeply-resident receiver — a near-full node in the neighborhood —
+*would* benefit, and could privately agree a deeper `L` with its senders.)
 
-**Convention — `L = 24` (3-byte targets).** Interoperating sender and receiver
-implementations MUST agree on `L`: a receiver pulls the bins a message at prefix
-`L` can occupy, so a sender mining to a different `L` may land where the receiver
-is not looking. This SWIP adopts **24 bits (3 bytes)** as the normative
-convention, on the recommendation of the Swarm protocol's designer:
+**Convention — `L = 16` (2-byte targets), with a `2..maxTargetDepth` range.**
+Interoperating sender and receiver implementations MUST agree on `L`: a receiver
+pulls the bins a message at prefix `L` can occupy, so a sender mining to a
+different `L` may land where the receiver is not looking. This SWIP adopts
+**16 bits (2 bytes)** as the interoperability default:
 
-- Senders SHOULD mine `targets` to 3 bytes; receivers assume `L = 24`.
-- 2 bytes remains the hard `invalid_target` floor (below the network storage
-  depth a chunk is not retained at all), and 1 byte is always rejected. A 2-byte
-  message is *stored* but a conforming `L = 24` receiver may not find it, so
-  2-byte sends are deprecated for interop.
-- 24 bits keeps the receiver's candidate traffic ~256× smaller than 16 and, per
-  [Delivery semantics](#delivery-semantics-normative), makes the whole
-  neighborhood trojan backlog small enough (~1–2K chunks) for the `history`
-  mailbox to recover *all* offline messages, not just a recent window.
+- Senders SHOULD mine `targets` to 2 bytes; receivers assume `L = 16`.
+- 2 bytes is also the hard `invalid_target` floor (below the network storage
+  depth a chunk is not retained at all); 1 byte is always rejected.
+- Implementations MAY mine deeper (up to `maxTargetDepth`) where sender and
+  receiver privately agree, but a conforming default receiver assumes 16.
 
-**Cost note (informative).** Mining is ~`2^L` hashes, so `L = 24` is ~256× a
-2-byte mine — sub-second on a server, but seconds on a constrained (mobile)
-sender. Implementations SHOULD mine off the request's critical path (background
-task / generous timeout) rather than blocking a send on it; a reference light
-node observed occasional send-timeout at `L = 24` under a 60 s budget until the
-timeout was raised.
+**Why not deeper.** A deeper prefix concentrates a trojan into a smaller slice of
+the reserve, which *in principle* cuts a receiver's candidate traffic and shrinks
+the recoverable mailbox backlog. But that benefit accrues only to a receiver
+**deeply resident** in the target neighborhood (covering peers at proximity
+`≥ L`); a light node's covering peers sit shallower, so it pulls the same bins
+and downloads the same candidates regardless of `L` — measured identical at
+`L = 16` and `L = 24` on a reference light node. Meanwhile mining is `~2^L`
+hashes, so each extra byte is ~256× the sender work: `L = 24` is seconds on a
+constrained (mobile) sender and can exceed a send timeout. Since PSS already
+carries an economic anti-spam gate — every send burns a **postage stamp** — the
+extra proof-of-work buys a light-node deployment little and costs its senders a
+lot. Hence the 2-byte default.
 
-Because `L` governs storage and retrieval for *every* PSS participant, not just
-this provider surface, it is arguably a network-wide parameter that belongs
-alongside the storage-depth conventions in the core Swarm protocol
-documentation; this SWIP fixes it at the provider boundary and defers any
-broader normative home to the core spec.
+**Open question (protocol-level).** Whether the network *should* mandate a deeper
+prefix as a deliberate anti-spam / anti-free-riding **proof-of-work** on senders
+— distinct from postage's economic gate — is a live protocol-incentive question
+raised by the Swarm protocol designer and still under discussion. It governs
+storage and retrieval for *every* PSS participant, not just this provider
+surface, so its normative home is arguably the core Swarm protocol
+documentation, not this extension; this SWIP fixes the provider default at 16 and
+will track any core-level decision.
 
 Broadcast a message on a topic. Any origin subscribed (via `swarm_subscribe`
 with `kind: "gsoc"`) to the address the topic derives to receives it.

--- a/SWIPs/swip-draft_provider_api_messaging.md
+++ b/SWIPs/swip-draft_provider_api_messaging.md
@@ -350,8 +350,10 @@ originally sent (a sender-supplied timestamp, if wanted, is application payload)
 Whether historical messages are ordered relative to each other is
 implementation-defined; applications needing send-order MUST carry their own
 sequence. The recoverable depth scales with the mining prefix length (see
-[PSS mining depth](#pss-mining-depth-prefix-length)): a deeper prefix makes the
-whole neighborhood backlog small enough to sweep completely.
+[PSS mining depth](#pss-mining-depth-prefix-length)): at the adopted `L = 24`
+convention the whole neighborhood backlog is small enough (~1–2K chunks) to
+sweep completely, so the mailbox recovers *all* retained offline messages, not
+just a recent window.
 
 ---
 
@@ -460,16 +462,34 @@ backlog on subscribe, which is exactly what makes the `history` mailbox
 targets thus cost the sender more to mine but make the receiver dramatically
 cheaper and unlock complete offline delivery.
 
-**Convention.** Implementations MUST reject `targets`/`pssTarget` shorter than 2
-bytes (`invalid_target`) and SHOULD document the mining prefix they use.
-Interoperating sender and receiver implementations MUST agree on `L`: a receiver
-pulls the bins a message at prefix `L` can occupy, so a sender mining to a
-different `L` may land where the receiver is not looking. This SWIP does not yet
-pin a single normative `L` — 2 bytes maximizes compatibility with today's
-senders, 3 bytes is materially better for receiver cost and offline delivery —
-and flags it as an open question for the Swarm community (it is arguably a
-network-wide parameter that belongs alongside the storage-depth conventions in
-the core protocol docs, not only in this provider spec).
+**Convention — `L = 24` (3-byte targets).** Interoperating sender and receiver
+implementations MUST agree on `L`: a receiver pulls the bins a message at prefix
+`L` can occupy, so a sender mining to a different `L` may land where the receiver
+is not looking. This SWIP adopts **24 bits (3 bytes)** as the normative
+convention, on the recommendation of the Swarm protocol's designer:
+
+- Senders SHOULD mine `targets` to 3 bytes; receivers assume `L = 24`.
+- 2 bytes remains the hard `invalid_target` floor (below the network storage
+  depth a chunk is not retained at all), and 1 byte is always rejected. A 2-byte
+  message is *stored* but a conforming `L = 24` receiver may not find it, so
+  2-byte sends are deprecated for interop.
+- 24 bits keeps the receiver's candidate traffic ~256× smaller than 16 and, per
+  [Delivery semantics](#delivery-semantics-normative), makes the whole
+  neighborhood trojan backlog small enough (~1–2K chunks) for the `history`
+  mailbox to recover *all* offline messages, not just a recent window.
+
+**Cost note (informative).** Mining is ~`2^L` hashes, so `L = 24` is ~256× a
+2-byte mine — sub-second on a server, but seconds on a constrained (mobile)
+sender. Implementations SHOULD mine off the request's critical path (background
+task / generous timeout) rather than blocking a send on it; a reference light
+node observed occasional send-timeout at `L = 24` under a 60 s budget until the
+timeout was raised.
+
+Because `L` governs storage and retrieval for *every* PSS participant, not just
+this provider surface, it is arguably a network-wide parameter that belongs
+alongside the storage-depth conventions in the core Swarm protocol
+documentation; this SWIP fixes it at the provider boundary and defers any
+broader normative home to the core spec.
 
 Broadcast a message on a topic. Any origin subscribed (via `swarm_subscribe`
 with `kind: "gsoc"`) to the address the topic derives to receives it.


### PR DESCRIPTION
## Summary

This PR proposes a new draft SWIP defining a standard JavaScript provider API — `window.swarm` — that lets web pages request access to a user's Swarm (Bee) node for publishing data, uploading files, managing mutable feeds, reading and writing indexed feed entries, and introspecting their own feed records. It follows the request/response pattern established by [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) for Ethereum providers, adapted for Swarm's publishing and feed primitives.

The draft lives at [`SWIPs/swip-draft_provider_api.md`](SWIPs/swip-draft_provider_api.md) and will be renamed to `swip-XXXX.md` once a number is assigned.

## Motivation

Today, publishing to Swarm from a web app requires either:

1. Direct HTTP calls to a locally running Bee node — exposing the **full** API surface (including administrative, debug and staking endpoints) to any page that can reach `localhost`, or
2. Server-side publishing infrastructure — defeating the point of decentralized hosting.

Neither is acceptable for a user-sovereign web. Users need a way to grant web apps controlled, permissioned access to Swarm publishing — the way `window.ethereum` lets pages interact with a wallet without exposing private keys. Without a standard, every Swarm-enabled browser or extension will invent its own API, fragmenting the ecosystem.

## What the SWIP specifies

- **Provider object** (`window.swarm`) injected before `DOMContentLoaded`, with `request()`, convenience wrappers, and an event interface.
- **Ten RPC methods** covering: connection (`swarm_requestAccess`), capability discovery (`swarm_getCapabilities`), publishing (`swarm_publishData`, `swarm_publishFiles`, `swarm_getUploadStatus`), mutable feeds (`swarm_createFeed`, `swarm_updateFeed`), indexed feed entries (`swarm_writeFeedEntry`, `swarm_readFeedEntry`), and origin-scoped feed introspection (`swarm_listFeeds`).
- **Permission model** with explicit user consent, **origin normalization** (so all dweb content served from `127.0.0.1` doesn't collapse into one permission scope), and **app-scoped feed identities** (each origin's feeds signed by a per-origin derived key, so dApps can't impersonate the user's main wallet).
- **Read-only methods on public Swarm data** (feed entry reads, listing the calling origin's own feeds) require **no permission grant**, since the same data is fetchable via any Bee gateway and gating it would be friction without security benefit.
- **Exact-match requirements** on indexed feed reads/writes (with implementation notes on Bee's `GET /feeds/{owner}/{topic}` at-or-before semantics and the SOC-address fallback) so overwrite protection and explicit-index reads are safe.
- **Capability-advertised limits** (`maxDataBytes`, `maxPathBytes`) so future implementations supporting PAX tar can advertise larger paths without breaking the spec.
- **Security considerations** covering origin trust, resource exhaustion, iframe behavior, key material isolation, and temp artifact cleanup.
- **Future extensions** explicitly out of scope for 1.0 (`capabilitiesChanged` event, `preferredIdentityMode`, encoding parameter for reads, promotion path for `specVersion`).

## Reference implementations

This is not a paper spec — both sides of the API are already implemented and exercise the full surface:

- **Provider:** [Freedom Browser](https://github.com/solardev-xyz/freedom-browser) ([PR #19](https://github.com/solardev-xyz/freedom-browser/pull/19)) injects `window.swarm` into webview contexts, with main-process IPC enforcement, origin normalization, app-scoped feed keys, and per-origin permissions.
- **Consumer dApp:** [Swarmit](https://github.com/flotob/swarmit) — a decentralized message board — uses `swarm_requestAccess`, `swarm_publishData`, `swarm_createFeed`, `swarm_writeFeedEntry`, `swarm_readFeedEntry`, and `swarm_listFeeds` for its full publishing and profile-discovery pipeline.

The implementation work surfaced several spec issues that have already been folded back into this draft (USTAR tar's 100-byte path limit, Bee's at-or-before feed lookup semantics, the SOC-address endianness trap, permission gating for public reads).

## Status

- **Status:** Draft — opening this PR to register the SWIP and begin discussion.
- **Developer Documentation:** [Swarm Provider JavaScript API](https://swarm-api.freedombrowser.eth.limo/)
- **Discussion:** [Swarm Discord — SWIPs channel](https://discord.com/channels/799027393297514537/1239813439136993280).
- Happy to iterate on naming, scope, and any specifics before this is endorsed. Filename will be renamed from `swip-draft_provider_api.md` to `swip-XXXX.md` once a number is assigned.
