### PR TITLE
SWIP-51: Redistribution spam and griefing mitigation

### DIFF
--- a/SWIPs/swip-24.md
+++ b/SWIPs/swip-24.md
@@ -1,0 +1,581 @@
+---
+SWIP: 24
+title: Redistribution spam and griefing mitigation
+author: Marko Cardinal (@0xCardiE)
+discussions-to: https://discord.gg/Q6BvSkCv (Swarm Discord '#swips')
+status: Draft
+type: Standards Track
+category: Core
+created: 2026-07-16
+requires: 21
+---
+
+# Redistribution spam and griefing mitigation
+
+## Simple Summary
+
+Sybil stakers can spam the `Redistribution` commit phase with many identities, making `claim()` too expensive to run and blocking round finalization without penalty. This SWIP documents the threat model, quantifies gas thresholds on Gnosis Chain, and specifies a mitigation package: bounded online admission, staged participation finalization, and proof validation before subjective penalties or payout.
+
+## Abstract
+
+The Swarm storage-incentives `Redistribution` contract runs a three-phase Schelling game (commit, reveal, claim) to select winners and adjust storage prices. The current design allows an unbounded `currentCommits` array. A sybil farm of N staked addresses increases claim-phase work linearly in N and can exceed block or wallet gas limits, permanently blocking a round's payout.
+
+Several contract bugs amplify the attack: penalties computed in `winnerSelection()` roll back when proof verification fails; zero-reveal rounds never enter the penalty path; and payout failure is treated as success. Depth floors and proximity checks raise sybil cost but do not cap N.
+
+This SWIP proposes a three-layer fix: (1) bounded online admission with stake-weighted selection, (2) participation finalization that persists objective non-reveal penalties before proofs, and (3) proof-gated disagreement penalties, oracle adjustment, and payout. The package bounds gas and fixes penalty rollback but does not alone solve all-revealing fabricated-hash coalitions; that requires objective reveal validation or a bounded timeout/fallback protocol.
+
+## Motivation
+
+The redistribution game is the core on-chain mechanism that pays storer nodes from the PostageStamp pot and updates the price oracle ([SWIP-21](./swip-21.md)). Liveness of `claim()` is therefore a protocol-level requirement: if rounds cannot finalize, rewards stall and price discovery breaks.
+
+Today, any staked identity can commit once per round with no hard cap on total commits. Claim work scales as O(N) over commits across `getCurrentTruth()`, `winnerSelection()`, and related loops. Commit-phase work scales as O(N²) across the round due to overlay-uniqueness scans, which partially deters attackers but does not protect the winner's single `claim()` transaction.
+
+Production `Redistribution` deploys on Gnosis Chain (chainId 100), where blocks are approximately 17M gas. Engineering estimates suggest on the order of 100 sybil commit-only identities can exceed conservative wallet limits and ~660 can approach the block gas cliff — achievable with roughly 6,600 BZZ minimum locked stake at height 0, plus gas.
+
+No real Bee nodes or stored chunks are required for the attack. `commit()` and `reveal()` only check stake, phase, commit-wrap consistency, and proximity. Reserve commitment hashes are not validated against storage until `claim()` proof verification.
+
+Depth-floor policy is complementary but insufficient on its own; see [storage-incentives depth-floor options](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/MINIMUM_DEPTH_OPTIONS.md).
+
+## Specification
+
+### Threat model summary
+
+The main griefing vector is a sybil farm: many staked addresses, each with one commit per round, inflating `currentCommits` so `claim()` does linear work in `getCurrentTruth()` and `winnerSelection()`.
+
+Current contract limits:
+
+- `currentCommits` is unbounded, so `claim()` work scales linearly with sybil count.
+- **Bug:** penalties, oracle adjustment, and payout all run inside one atomic `claim()`; proof failure rolls back every `freezeDeposit()` and leaves blocking nodes unpenalized.
+- Round state is global and arrays are bulk-deleted on rollover, so spam can also grief the next round.
+
+Proposed fix:
+
+1. A **bounded online admission set** whose storage and per-call work are capped at all times.
+2. **Participation finalization** that persists only objective non-reveal penalties.
+3. Proof validation before disagreement penalties, oracle adjustment, or payout.
+4. Current-round-only payout rights, retryable withdrawal, explicit deadlines, and enforced step ordering so the winner must complete the chain to receive the pot.
+
+This bounds gas and keeps false truth from triggering disagreement penalties or payout. It does **not** by itself solve an all-revealing coalition that reports the same fabricated hash; objective reveal validation or a bounded timeout/fallback protocol is still required for that liveness guarantee.
+
+### Attacker capabilities
+
+The practical attack is a sybil farm: many staked addresses, each participating once per round.
+
+#### Hard limits per identity
+
+- One commit per overlay per round. `commit()` scans `currentCommits` and reverts with `AlreadyCommitted()` if that overlay already exists.
+- One reveal per commit. `AlreadyRevealed()` prevents double reveal.
+
+Scale is bounded by number of sybil stakers, not unlimited transactions from one wallet.
+
+#### Entry requirements (each sybil)
+
+1. Minimum stake: `MIN_STAKE * 2^height` on first deposit in `Staking.sol` (`MIN_STAKE = 1e17` at height 0).
+2. Two-round wait: `MustStake2Rounds` before the first commit.
+3. Gas: one commit tx and optionally one reveal tx per round.
+4. Stake updates reset the wait: any `manageStake()` call updates `lastUpdatedBlockNumber`, restarting the two-round eligibility clock.
+
+#### Commit vs reveal asymmetry
+
+- `commit()` does not check proximity. Any staked node can enter `currentCommits`.
+- `reveal()` checks proximity via `inProximity()`.
+
+If `_depth == height`, then `depthResponsibility = 0` and proximity always passes (`inProximity(..., 0)` is true for every overlay). That is the cheapest valid reveal path (lowest `stakeDensity`, easiest proximity).
+
+An existing staker can also call `manageStake(nonce, 0, newHeight)` without adding tokens. Minimum stake is enforced only on first deposit, so a mature minimum-funded stake can later set `height` to match a declared floor and keep `depth == height`.
+
+#### Who can call `claim()`
+
+`claim()` has no `msg.sender` check. Any party that supplies valid proofs can submit the transaction and pay gas; the pot is withdrawn to `winner.owner`, not the caller. Relayers or griefers can therefore attempt claims on behalf of the network.
+
+### Where array growth hurts
+
+Several paths loop over `currentCommits.length`:
+
+| Phase  | Function            | Cost per operation      |
+|--------|---------------------|-------------------------|
+| Commit | overlay uniqueness  | O(n) per new commit     |
+| Reveal | `findCommit()`      | O(n) per reveal         |
+| Claim  | `getCurrentTruth()` | O(n) over all commits   |
+| Claim  | `winnerSelection()` | O(n) again              |
+| View   | `isWinner()`        | O(n) again              |
+
+A farm of N sybil nodes increases claim work linearly in N. Per-iteration cost is not uniform: commit-only sybils are cheap in `getCurrentTruth()` but expensive in `winnerSelection()` because of `freezeDeposit()` external calls.
+
+Arrays reset each round (`delete currentCommits` at the start of a new commit phase), but Solidity storage cleanup scales with occupied slots. Current-round spam can therefore make rollover itself expensive or uncallable. The fix must cap cleanup too, using fixed-capacity/generation-tagged state, a ring buffer, or bounded cursor cleanup.
+
+### Attack scenarios
+
+#### 1. Zero-reveal round lock (cheapest path)
+
+**Attack:** many sybil commits, no reveals.
+
+**Effect:** `claim()` reverts `NoReveals()` before `getCurrentTruth()` or the penalty loop, because `currentRevealRound` is only set on the first successful reveal. No `freezeDeposit()` runs; no oracle adjustment; no loop bloat at claim time.
+
+**What breaks:** the round cannot be claimed. The pot continues to accrue in PostageStamp. After the claim phase ends or the next round begins, that round is permanently unclaimable. Its arrays are deleted on rollover and cannot shrink mid-round.
+
+**Cost to attacker:** commit gas only (O(N²) across the round). No stake freeze. No reveals and no real storage required.
+
+**Bug:** with no reveals, `claim()` reverts `NoReveals()` and the penalty path never runs. Commit-only sybils are never frozen.
+
+#### 2. Claim-phase gas griefing
+
+**Attack:** N sybil commits plus at least one reveal (honest or dishonest).
+
+**Effect:** `claim()` runs `winnerSelection()` over all N commits. If gas exceeds the transaction or block limit, the entire transaction reverts atomically. `currentClaimRound` is not updated; all `freezeDeposit()` calls in that tx are rolled back.
+
+**Who pays:** whoever calls `claim()` and supplies proofs.
+
+**What breaks:** the round does not finalize while N stays high. Every retry in the same claim phase repeats the same O(N) work. If no successful claim occurs before rollover, the round becomes unclaimable; the accumulated pot remains for a later successful withdrawal.
+
+Penalties apply only when a `claim()` transaction fully succeeds. A grief that blocks every claim is penalty-free for the attacker. Sybil reveals can use fabricated hashes; the attacker does not need to win or pass proof checks.
+
+**Bug:** same penalty rollback as attack 3 — failed or out-of-gas `claim()` reverts all `freezeDeposit()` calls from `winnerSelection()`.
+
+#### 3. Truth poisoning / proof deadlock
+
+**Attack:** sybil reveals with a fabricated `(hash, depth)` and enough aggregate `stakeDensity` to be selected as truth.
+
+**Effect:** truth selection is a stake-density-weighted lottery over individual reveals, not a majority vote or correctness check. `reveal()` does not verify that the hash exists in storage; any revealed tuple can become truth with probability proportional to its `stakeDensity`. Commit order also influences the draw because randomness is keyed on commit array index `i`.
+
+If a fabricated hash is selected:
+
+- Only reveals matching that exact `(hash, depth)` enter winner selection.
+- Honest nodes cannot supply valid chunk proofs for the selected hash.
+- `claim()` reverts during proof verification; penalties and `currentClaimRound` roll back with the tx.
+
+A single malicious reveal in a round becomes truth deterministically. This is a liveness attack independent of exceeding gas limits.
+
+**Bug:** dishonest nodes can block every `claim()` attempt without being penalized. `winnerSelection()` applies `freezeDeposit()` before proofs are checked; when inclusion verification fails, the whole transaction reverts and none of those freezes persist. Blocking payout is effectively free for the attacker.
+
+**Fix:** split finalization so objective non-reveal penalties persist before proof validation. Apply disagreement penalties and oracle adjustment only after the selected truth passes storage proofs.
+
+#### 4. Commit-only spam with at least one reveal
+
+**Attack:** many commits, one honest or sybil reveal, all other sybils skip reveal.
+
+**Effect:** bloats the `winnerSelection()` loop. Each non-revealed commit can trigger `freezeDeposit()` only if the full `claim()` succeeds. Freeze duration scales as `2 ** truthRevealedDepth`, not the offender's own depth.
+
+With default `penaltyRandomFactor = 100`, disagreeing reveals are also always frozen when claim succeeds.
+
+**Bug:** same as attack 3 — if `claim()` never completes, non-reveal freezes computed in `winnerSelection()` are rolled back and commit-only sybils stay unpenalized.
+
+### Gas model
+
+#### Illustrative baseline (unverified)
+
+The following figures are engineering estimates, not regression-tested benchmarks. No `gasUsed` assertions for sybil scaling exist in `test/Redistribution.test.ts` today. Re-measure on a Gnosis-compatible fork before relying on thresholds.
+
+These are claim-side thresholds only. Attack feasibility must also account for the 38-block commit window: O(N²) uniqueness scans consume aggregate block gas and late commits become individually expensive. Benchmark the complete round, not just one `claim()` transaction.
+
+| Participants | Commits | Reveals | `claim()` gas (illustrative) |
+|--------------|---------|---------|------------------------------|
+| 1 honest     | 1       | 1       | ~450,000                     |
+| 1 honest + 5 sybil commit-only | 6 | 1 | ~570,000 |
+
+Marginal cost per extra commit-only sybil in `winnerSelection()` (loop + `freezeDeposit()`): ~25,000 gas (order-of-magnitude).
+
+Proof verification (BMT inclusion, stamp, SOC) dominates the baseline (~400k+ gas) but scales weakly with N. Loop + freeze work scales linearly with commit count.
+
+#### Approximate formula
+
+```
+G_claim(N) ≈ G_base + (N − 1) × G_sybil
+```
+
+Where (illustrative):
+
+- `G_base` ≈ 450k gas: one honest commit + reveal + full proof path
+- `G_sybil` ≈ 25k gas: each additional commit-only sybil when claim runs (freeze + loop)
+
+Dishonest reveals add similar or slightly higher marginal cost. The zero-reveal variant (scenario 1) incurs no claim gas at all.
+
+#### Threshold estimates
+
+Solve `G_base + (N − 1) × G_sybil > G_limit`:
+
+| Limit | Typical context | Approx. sybils to exceed |
+|-------|-----------------|---------------------------|
+| ~3M gas | Conservative wallet / RPC cap | ~100-110 |
+| ~10M gas | Generous tx cap | ~390-400 |
+| ~16.78M gas | Post-Fusaka per-transaction cap | ~650-660 |
+| ~17M gas | Gnosis Chain block limit (production) | ~660-680 |
+
+Production `mainnet` in [storage-incentives](https://github.com/ethersphere/storage-incentives) deploys to Gnosis Chain (chainId 100), not Ethereum L1. Size from the stricter limit with substantial operational margin; do not target the cliff or use Ethereum's historical ~30M figure.
+
+Examples (illustrative formula):
+
+- N = 100: ~450k + 99×25k ≈ 2.9M gas (may fail under tight wallet limits)
+- N = 500: ~450k + 499×25k ≈ 12.9M gas
+- N = 660: ~450k + 659×25k ≈ ~17M gas (Gnosis block-limit cliff)
+
+Re-measure after contract, compiler, or proof changes. Cold/warm storage, calldata size, external-call costs, the commit-phase block budget, and the chain's current block gas limit can shift coefficients.
+
+#### Commit-phase cost to the attacker
+
+Each sybil commit scans the full commit array: total attacker gas to fill N slots is O(N²) across the round. That is a partial economic deterrent but does not protect the winner's single `claim()` tx.
+
+### Economic cost to spam
+
+Per sybil at `height = 0` (minimum path):
+
+| Item | Cost |
+|------|------|
+| Minimum stake | `MIN_STAKE` = 1e17 base units = 10 BZZ (token uses 16 decimals) |
+| Time lock | 2 × ROUND_LENGTH blocks (~304 blocks, ~25 min at 5s/block) before first commit |
+| Commit + reveal gas | Paid every round (chain-dependent) |
+| Freeze after penalized behavior | `freezeDeposit()` moves the staking timestamp into the future; the normal two-round maturity check still applies afterward |
+
+Example: ~100 sybils for wallet-limit griefing ≈ 1,000 BZZ minimum locked stake at height 0, plus gas. If every claim is successfully blocked, no freeze is applied.
+
+Example: ~660 sybils for Gnosis block-limit griefing ≈ 6,600 BZZ minimum locked stake at height 0, plus O(N²) commit gas and operational burden.
+
+Eligibility rules change how sybils must stake and reveal. Bounded work is what caps N and protects claim liveness.
+
+Effective re-entry is approximately the configured freeze duration **plus two rounds**, not merely the nominal freeze interval.
+
+### Mitigation package
+
+The package has three layers:
+
+```
+bounded online admission
+        +
+objective participation finalization
+        +
+proof validation before subjective penalties, oracle update, and payout
+```
+
+Supporting eligibility rules (depth floor, proximity, declared depth) raise sybil cost but do not cap N on their own.
+
+This package bounds gas and safely persists non-reveal penalties. It deliberately does not claim that fabricated reveals are solved: if false reveals must be prevented from suppressing every payout, reveal-time validity proof or a separately audited bounded fallback protocol is required.
+
+### Penalty gaps in the current contract
+
+Penalties are the main reason a capped sybil farm cannot attack every round cheaply. Today there are four bugs and one economic limitation.
+
+#### Gap 1: penalties live inside the same tx as proofs (bug)
+
+`claim()` calls `winnerSelection()` first, then verifies proofs:
+
+```solidity
+function claim(...) external {
+    winnerSelection();   // freezeDeposit() for non-reveal / wrong-truth
+    // ... proof verification (reverts on failure)
+    // ... withdraw pot
+}
+```
+
+Any proof revert rolls back the entire transaction, including all `freezeDeposit()` calls and `currentClaimRound`. So a sybil winner with a fake hash can undo penalties for everyone by failing proofs.
+
+This is a bug that must be fixed: dishonest play should trigger penalization, not a full rollback of punishments already computed.
+
+#### Gap 2: zero reveals means no penalty path (bug)
+
+`winnerSelection()` reverts `NoReveals()` when `currentRevealRound != currentRound`. That happens when nobody revealed in the round (`currentRevealRound` is only set on the first successful reveal).
+
+The penalty loop never runs. Commit-only sybils pay commit gas only and stay unfrozen.
+
+#### Gap 3: freeze is a time-lock, not a slash (economic limitation)
+
+`freezeDeposit()` prevents participation for a period. Stake is not destroyed. After the freeze ends the same capital can attack again (with new wallets still needing the two-round staking wait). This raises repeat-attack cost but is not a protocol bug.
+
+#### Gap 4: disagreement penalties require validated truth
+
+Failure to reveal is objective after the reveal deadline. Disagreement is relative to a lottery-selected tuple that may be fabricated and cannot pass storage proofs.
+
+Only non-reveal penalties belong in proof-independent finalization. Disagreement penalties and oracle adjustment require a validated truth.
+
+#### Gap 5: payout failure is currently treated as success (bug)
+
+`claim()` makes a low-level `PostageStamp.withdraw()` call, emits `WithdrawFailed` on failure, and still completes. Because `currentClaimRound` was already set, the winner cannot retry that round.
+
+Settlement must revert or retain an explicit retryable payout state when withdrawal fails. It must never emit final success or consume the round's payout right after a failed transfer.
+
+#### Who gets penalized today (only if full `claim()` succeeds)
+
+| Participant | Condition | Penalty |
+|-------------|-----------|---------|
+| Commit, no reveal | `!revealed` in loop | Always frozen (`penaltyMultiplierNonRevealed`) |
+| Reveal, wrong truth | hash/depth != truth | Frozen with probability `penaltyRandomFactor` |
+| Reveal, matches truth | exact tuple match | No disagreement penalty |
+| Selected winner | bad proofs | No penalty; whole tx reverts |
+
+### Safe staged finalization
+
+Use explicit current-round state and three stages. Today `claim()` is one transaction; the proposed design splits the claim phase into separate on-chain actions.
+
+#### Claim-phase actions
+
+| Round outcome | Transactions | Calls |
+|---------------|--------------|-------|
+| Zero reveals | **1** | `finalizeParticipation(round)` — freeze non-revealers, close round, no payout |
+| Reveals, happy path | **3** | `finalizeParticipation` → `verifyWinner(proofs)` → `settleRound` |
+| Reveals, proof failure | **1–2** | `finalizeParticipation` always persists non-reveal penalties; `verifyWinner` may fail/retry; `settleRound` is not reached |
+
+`settleRound` may need more than one attempt if withdrawal fails, but it remains a separate retryable step rather than replaying the full penalty and proof work.
+
+All claim-phase actions must complete within the current round's claim window (or the round's payout right expires at rollover).
+
+#### Caller incentives
+
+Today one `claim()` ties everything together: whoever submits valid proofs triggers payout to `winner.owner` in the same transaction. The winner (or a relayer acting on their behalf) has a direct economic reason to call it.
+
+The staged design must preserve that chain:
+
+| Step | Who is likely to call | Incentive |
+|------|----------------------|-----------|
+| `finalizeParticipation` | Anyone (permissionless) | **Weakest.** No pot is paid here. Non-revealers get frozen; tentative winner is stored. The tentative winner benefits indirectly and should call this before trying to prove, but can free-ride if they expect someone else to pay. Zero-reveal rounds have no winner — this step only closes the round and applies penalties. |
+| `verifyWinner` | Tentative winner or relayer | **Strong once step 1 ran.** Proofs are required; payout still does not happen in this tx. Same relayer model as today's `claim()`: pot goes to stored `winner.owner`, not `msg.sender`. |
+| `settleRound` | Tentative winner or relayer | **Strongest payout step.** Pot is withdrawn to stored `winner.owner` only after `truthValidated`. This is the step that actually pays. |
+
+**Requirement:** a round with reveals only pays if all three steps succeed in order before the claim deadline. The protocol should enforce that ordering (`participationFinalized` → `truthValidated` → payout) and that only the stored winner receives the pot.
+
+**Not specified yet (needs design):**
+
+- What incentivizes step 1 on zero-reveal rounds when there is no winner to call it.
+- Whether to expose a convenience wrapper (for example `verifyAndSettle(proofs)`) so the winner can complete steps 2–3 in one transaction while keeping the gas-bounded split internally.
+- Whether step 1 receives any explicit caller reward; this SWIP does not assume one.
+
+Without step 1, the winner cannot reach `verifyWinner` or `settleRound`. Without steps 2–3, the winner never receives the pot even if step 1 ran.
+
+#### 1. `finalizeParticipation(uint64 round)`
+
+Callable only after reveal closes and before a fixed finalization deadline:
+
+```solidity
+require(round == currentRound())
+require(selectedCount <= MAX_COMMITS)
+freeze only selected commits that did not reveal
+store tentative truth and tentative winner
+mark participationFinalized
+```
+
+If there are zero reveals, close the round with no truth, no oracle update, and no payout. If there are reveals, the selected tuple remains tentative.
+
+An empty round has no `truthRevealedDepth`, so its freeze duration cannot reuse the current truth-depth penalty formula. Define a bounded governed duration or derive a capped duration from each selected commit's stored responsibility.
+
+This stage must **not** freeze disagreeing revealers or adjust the oracle. A false tentative truth has not earned that authority.
+
+#### 2. `verifyWinner(uint64 round, proofs...)`
+
+During a bounded proof window:
+
+```solidity
+require(participationFinalized)
+require(tentative winner exists)
+verify chunk, stamp, SOC, order, and reserve-size proofs
+mark truthValidated
+```
+
+Invalid proofs revert only this transaction. Because anyone can submit `verifyWinner()` with deliberately invalid calldata, a failed transaction is not evidence that the selected winner cheated and must never directly slash/freeze the winner. A timeout penalty can apply to non-delivery at the deadline if that rule is specified in advance.
+
+Persist the round's reveal anchor, proof-selection seed, winner/truth, and proof parameters in `RoundState`; do not read mutable globals from a later phase. Stamp/proof reference timing against PostageStamp expiry is out of scope for this SWIP.
+
+#### 3. `settleRound(uint64 round)`
+
+After successful proof validation:
+
+```solidity
+require(truthValidated)
+apply bounded disagreement penalties
+adjust oracle using validated redundancy
+withdraw the current pot to the stored winner
+mark settled only after withdrawal succeeds
+```
+
+Payout failure must revert settlement or remain retryable.
+
+#### Deadlines and global-pot safety
+
+`PostageStamp.withdraw()` transfers the entire pot at call time; it does not escrow a round-specific amount. Therefore a stale finalized winner must not be allowed to claim in a later round after more value accrued.
+
+Use one of these audited models:
+
+1. **Current-round-only rights:** all three stages have deadlines inside the current claim phase. An unpaid reward expires at rollover and the pot carries forward. Past rounds cannot call `withdraw()`.
+2. **Escrowed round amount:** snapshot and reserve an amount in PostageStamp, then expose amount-bounded withdrawal. This requires a PostageStamp protocol change.
+
+Storing `finalized[round]` while calling the current global `withdraw()` later is unsafe.
+
+The design requires an explicit bounded `RoundState` record containing phase/status, reveal anchor, proof seed, tentative/validated truth, winner, and payment status. New rounds must not alias singleton proof context. Cleanup must be generation-tagged, fixed-capacity, or cursor-bounded; never bulk-delete attacker-sized arrays.
+
+#### Gas statement
+
+Set `MAX_COMMITS` only after fork benchmarks prove every stage and downstream call fits with margin at N = MAX. The ~2.9M figure above is an estimate for the current atomic `claim()` at N = 100; benchmark the staged implementation separately.
+
+### MAX_COMMITS and bounded admission
+
+#### Why a hard cap
+
+A cap bounds `currentCommits.length`, so finalization loops and external freeze calls stay under the block/wallet gas limit.
+
+#### Why not first-come-first-served
+
+If the first `MAX_COMMITS` txs win, sybils can race to fill slots and exclude honest nodes for that round. Admission must not be pure FCFS.
+
+#### Bounded online selection
+
+Keep at most `MAX_COMMITS` selected records throughout the commit phase. Each accepted transaction performs bounded work, for example O(log MAX) replacement in a fixed-capacity heap. Admission must not depend on a single end-of-phase transaction that scans unbounded state.
+
+Separate weight from random priority:
+
+```text
+weight = objectivelyLockedEffectiveStake(owner)
+entropy = H(domain, round, fixedRoundSeed, overlay)
+priority = auditedWeightedPriority(entropy, weight)
+```
+
+Requirements:
+
+- `overlay` must be fixed by a stake old enough to satisfy the two-round wait.
+- Near-term admission weight is stake-only. Declared depth and proximity are eligibility filters, not weight, until depth has an objective pre-admission proof; otherwise fabricated deep declarations receive unearned priority.
+- Do not include `_obfuscatedHash`, reveal nonce, transaction index, or another user-grindable value in `entropy`.
+- Specify an exact integer weighted-sampling algorithm; prove/check overflow bounds and capital-splitting behavior.
+- Keep the best `MAX_COMMITS` priorities online and evict the current worst when appropriate.
+- Emit admission/eviction events and expose final selected status so clients know whether they must reveal.
+- Snapshot owner, overlay, height, effective stake, declared depth, weight, and priority at commit.
+- Bound auxiliary mappings and define cleanup. A fixed array plus an ever-growing "seen candidate" mapping is not bounded.
+
+The seed is known during commit in the simple online model. That permits mature identities to decide whether their fixed overlay has a favorable ticket, but avoids transaction-order dependence and arbitrary nonce grinding.
+
+Weighted admission improves proportional fairness; it does not guarantee an honest node a slot. Inclusion probability depends on honest weight versus total admitted attacker weight.
+
+For a side-by-side comparison of stake-weighted admission versus proximity-ranked admission under the same staged-finalization and eligibility baseline, see [ADMISSION_COMPARISON.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/ADMISSION_COMPARISON.md).
+
+### Eligibility rules (supporting layer)
+
+These raise sybil cost but do not cap N alone. They pair with `MAX_COMMITS`.
+
+**1. Extend `commit()` with stored depth**
+
+```solidity
+commit(bytes32 _obfuscatedHash, uint64 _roundNumber, uint8 _depth)
+```
+
+Store `declaredDepth` in `Commit`. At `reveal()`, require `_depth == declaredDepth` before proximity and floor checks.
+
+**2. Eligibility at commit**
+
+```
+require(height <= MAX_STAKE_HEIGHT)
+require(_depth <= MAX_REPORTED_DEPTH)
+require(_depth > height)
+depthResponsibility = _depth - height
+inProximity(overlay, currentRoundAnchor(), depthResponsibility)
+_depth >= currentFloor()
+```
+
+**3. Depth floor:** governed or bootstrap `currentFloor()`. Floor changes are round-versioned and activate only in a future round; store the applicable value in round/commit state so governance cannot accept a commit under one floor and force its reveal to fail under another. See [MINIMUM_DEPTH_OPTIONS.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/MINIMUM_DEPTH_OPTIONS.md).
+
+**4. Staking:** validate the resulting post-state on every height change, including `_addAmount == 0`: `potentialStake >= MIN_STAKE * 2^newHeight`. Specify whether `committedStake` is recomputed at the current oracle price; do not leave this to implementer interpretation.
+
+**5. Stake state:** ensure selected participants cannot withdraw or mutate stake/overlay/height during their obligation window. Snapshot values for selection, but apply penalties to the same owner/stake identity that created the commit.
+
+**6. Objective validity:** if all-revealing fabricated cohorts are in scope, require a bounded reveal-time sample/validity proof or design a timeout-and-fallback mechanism. This is a required liveness decision for attack 3, not an optional hardening item.
+
+### Attack mitigation matrix
+
+Attacks covered: (1) zero-reveal lock, (2) claim gas grief, (3) truth poisoning / penalty-free blocking, (4) commit-only spam.
+
+`MAX_COMMITS` remains a placeholder until measured. The examples below use K selected participants, not an assumed safe value of 100.
+
+#### 1. Zero reveal
+
+- Bounded admission limits work to K.
+- `finalizeParticipation()` freezes all selected non-revealers and closes the round.
+- This defense depends on someone calling `finalizeParticipation()` before the deadline.
+- The pot carries forward; there is no winner for that round.
+
+#### 2. Commit/reveal gas grief
+
+- Online admission keeps storage and each later scan bounded by K.
+- Fork benchmarks must cover worst-case K external freeze calls and not only happy-path proof verification.
+
+#### 3. Truth poisoning / proof deadlock
+
+- The fabricated tuple can still win the stake-weighted lottery; admission and floors do not prevent that.
+- Staged finalization stops a false truth from freezing honest disagreeing revealers or updating price before proofs pass.
+- **Fix for the penalty rollback bug:** `finalizeParticipation()` persists non-reveal freezes even when later proof validation fails.
+- All-revealing fabricated cohorts still need objective reveal validity or a timeout/fallback (see eligibility rule 6).
+
+#### 4. Commit-only spam with at least one reveal
+
+- Participation finalization persists non-reveal freezes before proof validation, fixing the rollback bug for commit-only sybils.
+- If an honest node was selected and reveals valid truth, settlement can apply disagreement policy, update the oracle, and pay.
+- Admission remains probabilistic: this outcome assumes the honest node was selected.
+
+#### Slot filling (supports attacks 1–4)
+
+- FCFS allows transaction-speed exclusion.
+- Bounded stake-weighted admission makes selection depend on fixed identity and objectively locked stake rather than arrival order.
+- It does not guarantee honest inclusion. A coalition with sufficient total weight can occupy all K positions.
+
+#### Rollover (supports attacks 1–2)
+
+- Fixed-cap/generation-tagged state prevents dynamic-array deletion from becoming the next-round DoS.
+
+## Rationale
+
+**Bounded admission vs. economic filters alone.** Depth floors, proximity, and stake minimums raise sybil cost but cannot cap per-round work. A hard `MAX_COMMITS` with stake-weighted online selection bounds gas while reducing pure FCFS racing.
+
+**Staged finalization vs. monolithic `claim()`.** Splitting participation finalization from proof validation fixes the penalty rollback bug: objective non-reveal penalties must persist even when a dishonest tentative winner fails proofs. Subjective disagreement penalties and oracle updates require validated truth.
+
+**Stake-weighted vs. proximity-ranked admission.** Stake weight aligns admission with existing truth-selection economics; proximity ranking is analyzed in [ADMISSION_COMPARISON.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/ADMISSION_COMPARISON.md). This SWIP recommends stake-weighted admission as the default.
+
+**Current-round-only payout rights.** Because `PostageStamp.withdraw()` transfers the global pot, stale winners must not withdraw after later rounds accrue value. Expiring unpaid rights at rollover is the lighter-weight option; escrow requires PostageStamp changes.
+
+**Fabricated-hash coalitions remain out of scope for the core package.** Admission and staged finalization prevent penalty-free blocking and gas grief but do not cryptographically prevent a coalition from revealing a shared fabricated hash. That requires a separate liveness mechanism (reveal-time validity proofs or timeout/fallback).
+
+## Backwards Compatibility
+
+This SWIP introduces breaking changes to the on-chain redistribution interface:
+
+- `commit()` gains a `_depth` parameter and admission may reject commits that would have been accepted under the current contract.
+- Atomic `claim()` is replaced by up to three claim-phase actions with new state fields and deadlines.
+- Round state layout changes from unbounded dynamic arrays to fixed-capacity, generation-tagged structures.
+
+Existing Bee clients and indexers must be updated to:
+
+- Track admission/eviction status during commit.
+- Call the staged finalization API instead of a single `claim()`.
+- Handle rounds that expire payout rights at rollover.
+
+Deployed contracts require upgrade or redeployment; there is no in-place migration path for in-flight rounds under the old layout.
+
+## Test Cases
+
+Mandatory before setting `MAX_COMMITS` and merging implementation:
+
+1. **Sybil scaling gas tests** on a Gnosis Chain fork: measure `claim()` and each staged step at N ∈ {1, 10, 100, 500, MAX_COMMITS} with commit-only and mixed reveal profiles.
+2. **Penalty persistence:** `finalizeParticipation()` followed by failing `verifyWinner()` must leave non-reveal freezes in place.
+3. **Zero-reveal rounds:** `finalizeParticipation()` must freeze commit-only sybils and close the round without payout.
+4. **Payout retry:** simulated `PostageStamp.withdraw()` failure must not consume payout rights; `settleRound()` must remain callable until success or deadline.
+5. **Admission fairness:** statistical tests that stake-weighted selection approximates proportional inclusion over many rounds.
+6. **Rollover cleanup:** worst-case K participants must not make next-round commit/reveal exceed block gas via storage deletion.
+
+Illustrative thresholds in the Specification section are not acceptance criteria until replaced by measured values from these tests.
+
+## Implementation
+
+Reference implementation and extended design notes live in the [storage-incentives](https://github.com/ethersphere/storage-incentives) repository:
+
+- [`Redistribution.sol`](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/src/Redistribution.sol)
+- [`Staking.sol`](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/src/Staking.sol)
+- [Threat model source document](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/SPAM_GRIEFING.md)
+- [Depth floor options](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/MINIMUM_DEPTH_OPTIONS.md)
+- [Admission comparison](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/ADMISSION_COMPARISON.md)
+
+**Status:** proposed mitigation architecture. Not yet implemented in production contracts.
+
+## Roadmap
+
+1. Fork benchmarks on Gnosis Chain to set `MAX_COMMITS` with margin.
+2. Specify exact weighted admission algorithm and `RoundState` layout.
+3. Implement staged finalization in `Redistribution.sol` and update Bee client.
+4. Decide step-1 caller incentives for zero-reveal rounds.
+5. Specify objective reveal validity or timeout/fallback for fabricated-hash coalitions.
+6. Governance parameters for depth floor versioning ([MINIMUM_DEPTH_OPTIONS.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/MINIMUM_DEPTH_OPTIONS.md)).
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/SWIPs/swip-51.md
+++ b/SWIPs/swip-51.md
@@ -14,410 +14,139 @@ requires: 21
 
 ## Simple Summary
 
-Sybil stakers can spam the `Redistribution` commit phase with many identities, making `claim()` too expensive to run and blocking round finalization without penalty. This SWIP documents the threat model, quantifies gas thresholds on Gnosis Chain, and specifies a mitigation package: bounded online admission, staged participation finalization, and proof validation before subjective penalties or payout.
+Sybil stakers can inflate `Redistribution` commit count so honest `claim()` becomes too expensive or fails proofs, blocking round payout without penalty. This SWIP lists those attacks, documents current contract bugs, and proposes bounded admission plus staged claim finalization.
 
 ## Abstract
 
-The Swarm storage-incentives `Redistribution` contract runs a three-phase Schelling game (commit, reveal, claim) to select winners and adjust storage prices. The current design allows an unbounded `currentCommits` array. A sybil farm of N staked addresses increases claim-phase work linearly in N and can exceed block or wallet gas limits, permanently blocking a round's payout.
+`Redistribution` runs commit → reveal → claim to pay storers and update the price oracle ([SWIP-21](./swip-21.md)). `currentCommits` is unbounded; claim work scales O(N). On Gnosis (~17M block gas), ~100 sybils can exceed wallet caps and ~660 can approach the block limit.
 
-Several contract bugs amplify the attack: penalties computed in `winnerSelection()` roll back when proof verification fails; zero-reveal rounds never enter the penalty path; and payout failure is treated as success. Depth floors and proximity checks raise sybil cost but do not cap N.
+Penalties computed in `winnerSelection()` roll back when proof verification fails; failed pot withdrawal still consumes the round. Depth floors raise cost but do not cap N.
 
-This SWIP proposes a three-layer fix: (1) bounded online admission with stake-weighted selection, (2) participation finalization that persists objective non-reveal penalties before proofs, and (3) proof-gated disagreement penalties, oracle adjustment, and payout. The package bounds gas and fixes penalty rollback but does not alone solve all-revealing fabricated-hash coalitions; that requires objective reveal validation or a bounded timeout/fallback protocol.
+**Proposed fix:** (1) stake-weighted bounded admission, (2) participation finalization that persists non-reveal penalties before proofs, (3) proof-gated disagreement penalties, oracle update, and payout. Fabricated-hash coalitions still need reveal-time validity or a timeout/fallback (out of scope for the core package).
 
 ## Motivation
 
-The redistribution game is the core on-chain mechanism that pays storer nodes from the PostageStamp pot and updates the price oracle ([SWIP-21](./swip-21.md)). Liveness of `claim()` is therefore a protocol-level requirement: if rounds cannot finalize, rewards stall and price discovery breaks.
+`claim()` liveness is a protocol requirement: stalled rounds stop rewards and price discovery. No real Bee storage is required to commit or reveal; chunk proofs are checked only at claim.
 
-Today, any staked identity can commit once per round with no hard cap on total commits. Claim work scales as O(N) over commits across `getCurrentTruth()`, `winnerSelection()`, and related loops. Commit-phase work scales as O(N²) across the round due to overlay-uniqueness scans, which partially deters attackers but does not protect the winner's single `claim()` transaction.
+Production deploys on Gnosis Chain (chainId 100), not Ethereum L1.
 
-Production `Redistribution` deploys on Gnosis Chain (chainId 100), where blocks are approximately 17M gas. Engineering estimates suggest on the order of 100 sybil commit-only identities can exceed conservative wallet limits and ~660 can approach the block gas cliff — achievable with roughly 6,600 BZZ minimum locked stake at height 0, plus gas.
-
-No real Bee nodes or stored chunks are required for the attack. `commit()` and `reveal()` only check stake, phase, commit-wrap consistency, and proximity. Reserve commitment hashes are not validated against storage until `claim()` proof verification.
-
-Depth-floor policy is complementary but insufficient on its own; see [storage-incentives depth-floor options](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/MINIMUM_DEPTH_OPTIONS.md).
+---
 
 ## Specification
 
-### Threat model summary
+### 1. Background
 
-The main griefing vector is a sybil farm: many staked addresses, each with one commit per round, inflating `currentCommits` so `claim()` does linear work in `getCurrentTruth()` and `winnerSelection()`.
+#### Attacker model
 
-Current contract limits:
+- **Sybil farm:** many staked addresses, one commit per overlay per round (`AlreadyCommitted`), one reveal per commit (`AlreadyRevealed`).
+- **Entry cost per sybil:** `MIN_STAKE * 2^height` (10 BZZ at height 0), two-round stake wait, commit/reveal gas. `manageStake()` resets the wait.
+- **Commit vs reveal:** `commit()` has no proximity check; `reveal()` requires proximity. Cheapest path: `depth == height` (proximity always passes, lowest `stakeDensity`).
+- **`claim()`:** permissionless — any caller with valid proofs pays gas; pot goes to `winner.owner`.
 
-- `currentCommits` is unbounded, so `claim()` work scales linearly with sybil count.
-- **Bug:** penalties, oracle adjustment, and payout all run inside one atomic `claim()`; proof failure rolls back every `freezeDeposit()` and leaves blocking nodes unpenalized.
-- Round state is global and arrays are bulk-deleted on rollover, so spam can also grief the next round.
+#### Where N hurts
 
-Proposed fix:
+| Phase  | Function            | Cost        |
+|--------|---------------------|-------------|
+| Commit | overlay uniqueness  | O(n) / tx   |
+| Reveal | `findCommit()`      | O(n) / tx   |
+| Claim  | `getCurrentTruth()` | O(n)        |
+| Claim  | `winnerSelection()` | O(n) + freeze calls |
 
-1. A **bounded online admission set** whose storage and per-call work are capped at all times.
-2. **Participation finalization** that persists only objective non-reveal penalties.
-3. Proof validation before disagreement penalties, oracle adjustment, or payout.
-4. Current-round-only payout rights, retryable withdrawal, explicit deadlines, and enforced step ordering so the winner must complete the chain to receive the pot.
+Commit-only sybils are cheap in truth selection but expensive in `winnerSelection()` (`freezeDeposit()` per non-revealer). Bulk `delete currentCommits` on rollover can also grief the next round if N is unbounded.
 
-This bounds gas and keeps false truth from triggering disagreement penalties or payout. It does **not** by itself solve an all-revealing coalition that reports the same fabricated hash; objective reveal validation or a bounded timeout/fallback protocol is still required for that liveness guarantee.
-
-### Attacker capabilities
-
-The practical attack is a sybil farm: many staked addresses, each participating once per round.
-
-#### Hard limits per identity
-
-- One commit per overlay per round. `commit()` scans `currentCommits` and reverts with `AlreadyCommitted()` if that overlay already exists.
-- One reveal per commit. `AlreadyRevealed()` prevents double reveal.
-
-Scale is bounded by number of sybil stakers, not unlimited transactions from one wallet.
-
-#### Entry requirements (each sybil)
-
-1. Minimum stake: `MIN_STAKE * 2^height` on first deposit in `Staking.sol` (`MIN_STAKE = 1e17` at height 0).
-2. Two-round wait: `MustStake2Rounds` before the first commit.
-3. Gas: one commit tx and optionally one reveal tx per round.
-4. Stake updates reset the wait: any `manageStake()` call updates `lastUpdatedBlockNumber`, restarting the two-round eligibility clock.
-
-#### Commit vs reveal asymmetry
-
-- `commit()` does not check proximity. Any staked node can enter `currentCommits`.
-- `reveal()` checks proximity via `inProximity()`.
-
-If `_depth == height`, then `depthResponsibility = 0` and proximity always passes (`inProximity(..., 0)` is true for every overlay). That is the cheapest valid reveal path (lowest `stakeDensity`, easiest proximity).
-
-An existing staker can also call `manageStake(nonce, 0, newHeight)` without adding tokens. Minimum stake is enforced only on first deposit, so a mature minimum-funded stake can later set `height` to match a declared floor and keep `depth == height`.
-
-#### Who can call `claim()`
-
-`claim()` has no `msg.sender` check. Any party that supplies valid proofs can submit the transaction and pay gas; the pot is withdrawn to `winner.owner`, not the caller. Relayers or griefers can therefore attempt claims on behalf of the network.
-
-### Where array growth hurts
-
-Several paths loop over `currentCommits.length`:
-
-| Phase  | Function            | Cost per operation      |
-|--------|---------------------|-------------------------|
-| Commit | overlay uniqueness  | O(n) per new commit     |
-| Reveal | `findCommit()`      | O(n) per reveal         |
-| Claim  | `getCurrentTruth()` | O(n) over all commits   |
-| Claim  | `winnerSelection()` | O(n) again              |
-| View   | `isWinner()`        | O(n) again              |
-
-A farm of N sybil nodes increases claim work linearly in N. Per-iteration cost is not uniform: commit-only sybils are cheap in `getCurrentTruth()` but expensive in `winnerSelection()` because of `freezeDeposit()` external calls.
-
-Arrays reset each round (`delete currentCommits` at the start of a new commit phase), but Solidity storage cleanup scales with occupied slots. Current-round spam can therefore make rollover itself expensive or uncallable. The fix must cap cleanup too, using fixed-capacity/generation-tagged state, a ring buffer, or bounded cursor cleanup.
-
-### Attack scenarios
-
-#### 1. Zero-reveal round lock (cheapest path)
-
-**Attack:** many sybil commits, no reveals.
-
-**Effect:** `claim()` reverts `NoReveals()` before `getCurrentTruth()` or the penalty loop, because `currentRevealRound` is only set on the first successful reveal. No `freezeDeposit()` runs; no oracle adjustment; no loop bloat at claim time.
-
-**What breaks:** the round cannot be claimed. The pot continues to accrue in PostageStamp. After the claim phase ends or the next round begins, that round is permanently unclaimable. Its arrays are deleted on rollover and cannot shrink mid-round.
-
-**Cost to attacker:** commit gas only (O(N²) across the round). No stake freeze. No reveals and no real storage required.
-
-**Bug:** with no reveals, `claim()` reverts `NoReveals()` and the penalty path never runs. Commit-only sybils are never frozen.
-
-#### 2. Claim-phase gas griefing
-
-**Attack:** N sybil commits plus at least one reveal (honest or dishonest).
-
-**Effect:** `claim()` runs `winnerSelection()` over all N commits. If gas exceeds the transaction or block limit, the entire transaction reverts atomically. `currentClaimRound` is not updated; all `freezeDeposit()` calls in that tx are rolled back.
-
-**Who pays:** whoever calls `claim()` and supplies proofs.
-
-**What breaks:** the round does not finalize while N stays high. Every retry in the same claim phase repeats the same O(N) work. If no successful claim occurs before rollover, the round becomes unclaimable; the accumulated pot remains for a later successful withdrawal.
-
-Penalties apply only when a `claim()` transaction fully succeeds. A grief that blocks every claim is penalty-free for the attacker. Sybil reveals can use fabricated hashes; the attacker does not need to win or pass proof checks.
-
-**Bug:** same penalty rollback as attack 3 — failed or out-of-gas `claim()` reverts all `freezeDeposit()` calls from `winnerSelection()`.
-
-#### 3. Truth poisoning / proof deadlock
-
-**Attack:** sybil reveals with a fabricated `(hash, depth)` and enough aggregate `stakeDensity` to be selected as truth.
-
-**Effect:** truth selection is a stake-density-weighted lottery over individual reveals, not a majority vote or correctness check. `reveal()` does not verify that the hash exists in storage; any revealed tuple can become truth with probability proportional to its `stakeDensity`. Commit order also influences the draw because randomness is keyed on commit array index `i`.
-
-If a fabricated hash is selected:
-
-- Only reveals matching that exact `(hash, depth)` enter winner selection.
-- Honest nodes cannot supply valid chunk proofs for the selected hash.
-- `claim()` reverts during proof verification; penalties and `currentClaimRound` roll back with the tx.
-
-A single malicious reveal in a round becomes truth deterministically. This is a liveness attack independent of exceeding gas limits.
-
-**Bug:** dishonest nodes can block every `claim()` attempt without being penalized. `winnerSelection()` applies `freezeDeposit()` before proofs are checked; when inclusion verification fails, the whole transaction reverts and none of those freezes persist. Blocking payout is effectively free for the attacker.
-
-**Fix:** split finalization so objective non-reveal penalties persist before proof validation. Apply disagreement penalties and oracle adjustment only after the selected truth passes storage proofs.
-
-#### 4. Commit-only spam with at least one reveal
-
-**Attack:** many commits, one honest or sybil reveal, all other sybils skip reveal.
-
-**Effect:** bloats the `winnerSelection()` loop. Each non-revealed commit can trigger `freezeDeposit()` only if the full `claim()` succeeds. Freeze duration scales as `2 ** truthRevealedDepth`, not the offender's own depth.
-
-With default `penaltyRandomFactor = 100`, disagreeing reveals are also always frozen when claim succeeds.
-
-**Bug:** same as attack 3 — if `claim()` never completes, non-reveal freezes computed in `winnerSelection()` are rolled back and commit-only sybils stay unpenalized.
-
-### Gas model
-
-#### Illustrative baseline (unverified)
-
-The following figures are engineering estimates, not regression-tested benchmarks. No `gasUsed` assertions for sybil scaling exist in `test/Redistribution.test.ts` today. Re-measure on a Gnosis-compatible fork before relying on thresholds.
-
-These are claim-side thresholds only. Attack feasibility must also account for the 38-block commit window: O(N²) uniqueness scans consume aggregate block gas and late commits become individually expensive. Benchmark the complete round, not just one `claim()` transaction.
-
-| Participants | Commits | Reveals | `claim()` gas (illustrative) |
-|--------------|---------|---------|------------------------------|
-| 1 honest     | 1       | 1       | ~450,000                     |
-| 1 honest + 5 sybil commit-only | 6 | 1 | ~570,000 |
-
-Marginal cost per extra commit-only sybil in `winnerSelection()` (loop + `freezeDeposit()`): ~25,000 gas (order-of-magnitude).
-
-Proof verification (BMT inclusion, stamp, SOC) dominates the baseline (~400k+ gas) but scales weakly with N. Loop + freeze work scales linearly with commit count.
-
-#### Approximate formula
+#### Gas and economics (illustrative)
 
 ```
-G_claim(N) ≈ G_base + (N − 1) × G_sybil
+G_claim(N) ≈ 450k + (N − 1) × 25k
 ```
 
-Where (illustrative):
+| Limit   | Context              | ~Sybils to exceed |
+|---------|----------------------|-------------------|
+| ~3M     | Wallet / RPC cap     | ~100              |
+| ~17M    | Gnosis block limit   | ~660              |
 
-- `G_base` ≈ 450k gas: one honest commit + reveal + full proof path
-- `G_sybil` ≈ 25k gas: each additional commit-only sybil when claim runs (freeze + loop)
+**Sepolia validation (round 74469, honest nodes active):** 100 sybil commits + ~7 honest → honest `claim()` used **2,842,847** gas (estimate ~2.9M). Claim succeeded; sybils frozen. Liveness break at N≈100 raises cost but did not block claim; higher N or truth poisoning required.
 
-Dishonest reveals add similar or slightly higher marginal cost. The zero-reveal variant (scenario 1) incurs no claim gas at all.
+Commit-phase attacker cost is O(N²) (uniqueness scans) — partial deterrent, not protection for the single `claim()` tx.
 
-#### Threshold estimates
+~100 sybils ≈ 1,000 BZZ locked at height 0; ~660 ≈ 6,600 BZZ. If every claim is blocked, no freeze applies (rollback bug). Re-measure on a Gnosis fork before setting `MAX_COMMITS`.
 
-Solve `G_base + (N − 1) × G_sybil > G_limit`:
+---
 
-| Limit | Typical context | Approx. sybils to exceed |
-|-------|-----------------|---------------------------|
-| ~3M gas | Conservative wallet / RPC cap | ~100-110 |
-| ~10M gas | Generous tx cap | ~390-400 |
-| ~16.78M gas | Post-Fusaka per-transaction cap | ~650-660 |
-| ~17M gas | Gnosis Chain block limit (production) | ~660-680 |
+### 2. Attacks
 
-Production `mainnet` in [storage-incentives](https://github.com/ethersphere/storage-incentives) deploys to Gnosis Chain (chainId 100), not Ethereum L1. Size from the stricter limit with substantial operational margin; do not target the cliff or use Ethereum's historical ~30M figure.
+All scenarios assume **honest nodes are playing** and at least one reveal exists in the round.
 
-Examples (illustrative formula):
+| # | Name | Attacker action | Effect on honest nodes | Blocks payout when |
+|---|------|-----------------|------------------------|--------------------|
+| **1** | Claim gas grief | N commits + ≥1 reveal (sybil or honest) | `winnerSelection()` O(N); claim gas grows linearly | Gas exceeds tx/block limit; every retry repeats full work |
+| **2** | Truth poisoning | Sybil reveals fabricated `(hash, depth)`; may win stake-weighted truth lottery | Honest proofs fail on selected hash | Proof revert rolls back entire `claim()` including penalties |
+| **3** | Commit-only spam | Same as **1** with one revealer, N−1 commit-only | Same loop bloat | Same as **1** — not a separate vector |
 
-- N = 100: ~450k + 99×25k ≈ 2.9M gas (may fail under tight wallet limits)
-- N = 500: ~450k + 499×25k ≈ 12.9M gas
-- N = 660: ~450k + 659×25k ≈ ~17M gas (Gnosis block-limit cliff)
+**Attack 1 detail:** Failed or OOG `claim()` reverts all `freezeDeposit()` calls. Attacker need not pass proofs — one sybil reveal is enough to enter the claim path.
 
-Re-measure after contract, compiler, or proof changes. Cold/warm storage, calldata size, external-call costs, the commit-phase block budget, and the chain's current block gas limit can shift coefficients.
+**Attack 2 detail:** Truth is a stake-density lottery keyed on commit index, not correctness. Sole sybil reveal wins truth deterministically; with multiple reveals, outcome is probabilistic. `reveal()` does not verify storage.
 
-#### Commit-phase cost to the attacker
+**Out of scope as sybil grief:** rounds where nobody reveals (empty network). No honest participant is harmed; pot accrues until someone plays.
 
-Each sybil commit scans the full commit array: total attacker gas to fill N slots is O(N²) across the round. That is a partial economic deterrent but does not protect the winner's single `claim()` tx.
+---
 
-### Economic cost to spam
+### 3. Current contract bugs
 
-Per sybil at `height = 0` (minimum path):
+| ID | Bug | Symptom |
+|----|-----|---------|
+| **B1** | Penalties inside same tx as proofs | Proof failure reverts all `freezeDeposit()` and `currentClaimRound` — blocking nodes stay unpenalized |
+| **B2** | Payout failure treated as success | `WithdrawFailed` emitted but round marked claimed; winner cannot retry |
+| **B3** | Unbounded `currentCommits` | Claim and rollover work scale with attacker-chosen N |
 
-| Item | Cost |
-|------|------|
-| Minimum stake | `MIN_STAKE` = 1e17 base units = 10 BZZ (token uses 16 decimals) |
-| Time lock | 2 × ROUND_LENGTH blocks (~304 blocks, ~25 min at 5s/block) before first commit |
-| Commit + reveal gas | Paid every round (chain-dependent) |
-| Freeze after penalized behavior | `freezeDeposit()` moves the staking timestamp into the future; the normal two-round maturity check still applies afterward |
+**Economic limitation (not a bug):** `freezeDeposit()` is a time-lock, not a slash; capital can return after freeze + two rounds.
 
-Example: ~100 sybils for wallet-limit griefing ≈ 1,000 BZZ minimum locked stake at height 0, plus gas. If every claim is successfully blocked, no freeze is applied.
-
-Example: ~660 sybils for Gnosis block-limit griefing ≈ 6,600 BZZ minimum locked stake at height 0, plus O(N²) commit gas and operational burden.
-
-Eligibility rules change how sybils must stake and reveal. Bounded work is what caps N and protects claim liveness.
-
-Effective re-entry is approximately the configured freeze duration **plus two rounds**, not merely the nominal freeze interval.
-
-### Mitigation package
-
-The package has three layers:
-
-```
-bounded online admission
-        +
-objective participation finalization
-        +
-proof validation before subjective penalties, oracle update, and payout
-```
-
-Supporting eligibility rules (depth floor, proximity, declared depth) raise sybil cost but do not cap N on their own.
-
-This package bounds gas and safely persists non-reveal penalties. It deliberately does not claim that fabricated reveals are solved: if false reveals must be prevented from suppressing every payout, reveal-time validity proof or a separately audited bounded fallback protocol is required.
-
-### Penalty gaps in the current contract
-
-Penalties are the main reason a capped sybil farm cannot attack every round cheaply. Today there are four bugs and one economic limitation.
-
-#### Gap 1: penalties live inside the same tx as proofs (bug)
-
-`claim()` calls `winnerSelection()` first, then verifies proofs:
-
-```solidity
-function claim(...) external {
-    winnerSelection();   // freezeDeposit() for non-reveal / wrong-truth
-    // ... proof verification (reverts on failure)
-    // ... withdraw pot
-}
-```
-
-Any proof revert rolls back the entire transaction, including all `freezeDeposit()` calls and `currentClaimRound`. So a sybil winner with a fake hash can undo penalties for everyone by failing proofs.
-
-This is a bug that must be fixed: dishonest play should trigger penalization, not a full rollback of punishments already computed.
-
-#### Gap 2: zero reveals means no penalty path (bug)
-
-`winnerSelection()` reverts `NoReveals()` when `currentRevealRound != currentRound`. That happens when nobody revealed in the round (`currentRevealRound` is only set on the first successful reveal).
-
-The penalty loop never runs. Commit-only sybils pay commit gas only and stay unfrozen.
-
-#### Gap 3: freeze is a time-lock, not a slash (economic limitation)
-
-`freezeDeposit()` prevents participation for a period. Stake is not destroyed. After the freeze ends the same capital can attack again (with new wallets still needing the two-round staking wait). This raises repeat-attack cost but is not a protocol bug.
-
-#### Gap 4: disagreement penalties require validated truth
-
-Failure to reveal is objective after the reveal deadline. Disagreement is relative to a lottery-selected tuple that may be fabricated and cannot pass storage proofs.
-
-Only non-reveal penalties belong in proof-independent finalization. Disagreement penalties and oracle adjustment require a validated truth.
-
-#### Gap 5: payout failure is currently treated as success (bug)
-
-`claim()` makes a low-level `PostageStamp.withdraw()` call, emits `WithdrawFailed` on failure, and still completes. Because `currentClaimRound` was already set, the winner cannot retry that round.
-
-Settlement must revert or retain an explicit retryable payout state when withdrawal fails. It must never emit final success or consume the round's payout right after a failed transfer.
-
-#### Who gets penalized today (only if full `claim()` succeeds)
+**Penalty table (only if full `claim()` succeeds today):**
 
 | Participant | Condition | Penalty |
 |-------------|-----------|---------|
-| Commit, no reveal | `!revealed` in loop | Always frozen (`penaltyMultiplierNonRevealed`) |
-| Reveal, wrong truth | hash/depth != truth | Frozen with probability `penaltyRandomFactor` |
-| Reveal, matches truth | exact tuple match | No disagreement penalty |
-| Selected winner | bad proofs | No penalty; whole tx reverts |
+| Commit, no reveal | `!revealed` | Always frozen |
+| Reveal, wrong truth | hash/depth ≠ truth | Frozen (`penaltyRandomFactor`) |
+| Reveal, matches truth | exact match | None |
+| Winner | bad proofs | Whole tx reverts; no one penalized |
 
-### Safe staged finalization
+---
 
-Use explicit current-round state and three stages. Today `claim()` is one transaction; the proposed design splits the claim phase into separate on-chain actions.
+### 4. Proposed mitigations
 
-#### Claim-phase actions
+Three layers — admission bounds work; staging fixes **B1** and **B2**; eligibility raises sybil cost.
 
-| Round outcome | Transactions | Calls |
-|---------------|--------------|-------|
-| Zero reveals | **1** | `finalizeParticipation(round)` — freeze non-revealers, close round, no payout |
-| Reveals, happy path | **3** | `finalizeParticipation` → `verifyWinner(proofs)` → `settleRound` |
-| Reveals, proof failure | **1–2** | `finalizeParticipation` always persists non-reveal penalties; `verifyWinner` may fail/retry; `settleRound` is not reached |
-
-`settleRound` may need more than one attempt if withdrawal fails, but it remains a separate retryable step rather than replaying the full penalty and proof work.
-
-All claim-phase actions must complete within the current round's claim window (or the round's payout right expires at rollover).
-
-#### Caller incentives
-
-Today one `claim()` ties everything together: whoever submits valid proofs triggers payout to `winner.owner` in the same transaction. The winner (or a relayer acting on their behalf) has a direct economic reason to call it.
-
-The staged design must preserve that chain:
-
-| Step | Who is likely to call | Incentive |
-|------|----------------------|-----------|
-| `finalizeParticipation` | Anyone (permissionless) | **Weakest.** No pot is paid here. Non-revealers get frozen; tentative winner is stored. The tentative winner benefits indirectly and should call this before trying to prove, but can free-ride if they expect someone else to pay. Zero-reveal rounds have no winner — this step only closes the round and applies penalties. |
-| `verifyWinner` | Tentative winner or relayer | **Strong once step 1 ran.** Proofs are required; payout still does not happen in this tx. Same relayer model as today's `claim()`: pot goes to stored `winner.owner`, not `msg.sender`. |
-| `settleRound` | Tentative winner or relayer | **Strongest payout step.** Pot is withdrawn to stored `winner.owner` only after `truthValidated`. This is the step that actually pays. |
-
-**Requirement:** a round with reveals only pays if all three steps succeed in order before the claim deadline. The protocol should enforce that ordering (`participationFinalized` → `truthValidated` → payout) and that only the stored winner receives the pot.
-
-**Not specified yet (needs design):**
-
-- What incentivizes step 1 on zero-reveal rounds when there is no winner to call it.
-- Whether to expose a convenience wrapper (for example `verifyAndSettle(proofs)`) so the winner can complete steps 2–3 in one transaction while keeping the gas-bounded split internally.
-- Whether step 1 receives any explicit caller reward; this SWIP does not assume one.
-
-Without step 1, the winner cannot reach `verifyWinner` or `settleRound`. Without steps 2–3, the winner never receives the pot even if step 1 ran.
-
-#### 1. `finalizeParticipation(uint64 round)`
-
-Callable only after reveal closes and before a fixed finalization deadline:
-
-```solidity
-require(round == currentRound())
-require(selectedCount <= MAX_COMMITS)
-freeze only selected commits that did not reveal
-store tentative truth and tentative winner
-mark participationFinalized
+```
+bounded online admission (MAX_COMMITS)
+        +
+finalizeParticipation — persist non-reveal penalties
+        +
+verifyWinner → settleRound — proofs before subjective penalties, oracle, payout
 ```
 
-If there are zero reveals, close the round with no truth, no oracle update, and no payout. If there are reveals, the selected tuple remains tentative.
+#### 4.1 Staged claim finalization
 
-An empty round has no `truthRevealedDepth`, so its freeze duration cannot reuse the current truth-depth penalty formula. Define a bounded governed duration or derive a capped duration from each selected commit's stored responsibility.
+Replace atomic `claim()` with ordered steps (same claim window; payout rights expire at rollover):
 
-This stage must **not** freeze disagreeing revealers or adjust the oracle. A false tentative truth has not earned that authority.
+| Step | Function | Persists on revert | Purpose |
+|------|----------|-------------------|---------|
+| 1 | `finalizeParticipation(round)` | **Yes** — non-reveal freezes | Store tentative truth/winner; cap loop at K commits |
+| 2 | `verifyWinner(round, proofs…)` | No | Validate chunk/stamp/SOC proofs; mark `truthValidated` |
+| 3 | `settleRound(round)` | Retryable | Disagreement penalties, oracle, pot withdraw — only after **B2**-safe success |
 
-#### 2. `verifyWinner(uint64 round, proofs...)`
+**Rules:**
 
-During a bounded proof window:
+- Step 1 must **not** freeze disagreeing revealers or adjust the oracle (tentative truth may be fabricated).
+- Invalid `verifyWinner` calldata must not slash the winner (anyone can submit bad proofs).
+- `PostageStamp.withdraw()` pulls the global pot — use current-round-only payout rights or round escrow (PostageStamp change).
+- Snapshot reveal anchor, proof seed, truth, winner in `RoundState`; no bulk-delete unbounded arrays — use fixed-cap / generation-tagged storage.
 
-```solidity
-require(participationFinalized)
-require(tentative winner exists)
-verify chunk, stamp, SOC, order, and reserve-size proofs
-mark truthValidated
-```
+**Open design:** step-1 caller incentive on empty rounds; optional `verifyAndSettle(proofs)` wrapper for steps 2–3.
 
-Invalid proofs revert only this transaction. Because anyone can submit `verifyWinner()` with deliberately invalid calldata, a failed transaction is not evidence that the selected winner cheated and must never directly slash/freeze the winner. A timeout penalty can apply to non-delivery at the deadline if that rule is specified in advance.
+#### 4.2 Bounded admission (`MAX_COMMITS`)
 
-Persist the round's reveal anchor, proof-selection seed, winner/truth, and proof parameters in `RoundState`; do not read mutable globals from a later phase. Stamp/proof reference timing against PostageStamp expiry is out of scope for this SWIP.
-
-#### 3. `settleRound(uint64 round)`
-
-After successful proof validation:
-
-```solidity
-require(truthValidated)
-apply bounded disagreement penalties
-adjust oracle using validated redundancy
-withdraw the current pot to the stored winner
-mark settled only after withdrawal succeeds
-```
-
-Payout failure must revert settlement or remain retryable.
-
-#### Deadlines and global-pot safety
-
-`PostageStamp.withdraw()` transfers the entire pot at call time; it does not escrow a round-specific amount. Therefore a stale finalized winner must not be allowed to claim in a later round after more value accrued.
-
-Use one of these audited models:
-
-1. **Current-round-only rights:** all three stages have deadlines inside the current claim phase. An unpaid reward expires at rollover and the pot carries forward. Past rounds cannot call `withdraw()`.
-2. **Escrowed round amount:** snapshot and reserve an amount in PostageStamp, then expose amount-bounded withdrawal. This requires a PostageStamp protocol change.
-
-Storing `finalized[round]` while calling the current global `withdraw()` later is unsafe.
-
-The design requires an explicit bounded `RoundState` record containing phase/status, reveal anchor, proof seed, tentative/validated truth, winner, and payment status. New rounds must not alias singleton proof context. Cleanup must be generation-tagged, fixed-capacity, or cursor-bounded; never bulk-delete attacker-sized arrays.
-
-#### Gas statement
-
-Set `MAX_COMMITS` only after fork benchmarks prove every stage and downstream call fits with margin at N = MAX. The ~2.9M figure above is an estimate for the current atomic `claim()` at N = 100; benchmark the staged implementation separately.
-
-### MAX_COMMITS and bounded admission
-
-#### Why a hard cap
-
-A cap bounds `currentCommits.length`, so finalization loops and external freeze calls stay under the block/wallet gas limit.
-
-#### Why not first-come-first-served
-
-If the first `MAX_COMMITS` txs win, sybils can race to fill slots and exclude honest nodes for that round. Admission must not be pure FCFS.
-
-#### Bounded online selection
-
-Keep at most `MAX_COMMITS` selected records throughout the commit phase. Each accepted transaction performs bounded work, for example O(log MAX) replacement in a fixed-capacity heap. Admission must not depend on a single end-of-phase transaction that scans unbounded state.
-
-Separate weight from random priority:
+- Hard cap on selected commits bounds all O(N) loops and freeze calls.
+- **Not FCFS** — sybils would race to fill slots. Use stake-weighted online selection:
 
 ```text
 weight = objectivelyLockedEffectiveStake(owner)
@@ -425,156 +154,90 @@ entropy = H(domain, round, fixedRoundSeed, overlay)
 priority = auditedWeightedPriority(entropy, weight)
 ```
 
-Requirements:
+Keep best K by priority; O(log K) eviction per commit. Emit admission/eviction events. Set K only after fork benchmarks at N = MAX with margin.
 
-- `overlay` must be fixed by a stake old enough to satisfy the two-round wait.
-- Near-term admission weight is stake-only. Declared depth and proximity are eligibility filters, not weight, until depth has an objective pre-admission proof; otherwise fabricated deep declarations receive unearned priority.
-- Do not include `_obfuscatedHash`, reveal nonce, transaction index, or another user-grindable value in `entropy`.
-- Specify an exact integer weighted-sampling algorithm; prove/check overflow bounds and capital-splitting behavior.
-- Keep the best `MAX_COMMITS` priorities online and evict the current worst when appropriate.
-- Emit admission/eviction events and expose final selected status so clients know whether they must reveal.
-- Snapshot owner, overlay, height, effective stake, declared depth, weight, and priority at commit.
-- Bound auxiliary mappings and define cleanup. A fixed array plus an ever-growing "seen candidate" mapping is not bounded.
+See [ADMISSION_COMPARISON.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/ADMISSION_COMPARISON.md) for stake-weighted vs proximity-ranked admission.
 
-The seed is known during commit in the simple online model. That permits mature identities to decide whether their fixed overlay has a favorable ticket, but avoids transaction-order dependence and arbitrary nonce grinding.
+#### 4.3 Eligibility rules (supporting — do not cap N alone)
 
-Weighted admission improves proportional fairness; it does not guarantee an honest node a slot. Inclusion probability depends on honest weight versus total admitted attacker weight.
+1. `commit(obfuscatedHash, round, depth)` — store `declaredDepth`; reveal must match.
+2. Commit requires proximity, `depth > height`, depth floor — see [MINIMUM_DEPTH_OPTIONS.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/MINIMUM_DEPTH_OPTIONS.md).
+3. Validate `potentialStake >= MIN_STAKE * 2^newHeight` on every height change.
+4. Lock stake/overlay/height for selected participants until obligation ends.
+5. **Separate decision (attack 2):** reveal-time validity sample or timeout/fallback for fabricated-hash coalitions.
 
-For a side-by-side comparison of stake-weighted admission versus proximity-ranked admission under the same staged-finalization and eligibility baseline, see [ADMISSION_COMPARISON.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/ADMISSION_COMPARISON.md).
+#### 4.4 Attack → mitigation map
 
-### Eligibility rules (supporting layer)
+| Attack | Primary fix | Also helps |
+|--------|-------------|------------|
+| Gas grief (1, 3) | `MAX_COMMITS` + staged loops | O(N²) commit cost (existing) |
+| Truth poison (2) | Staging: non-reveal freezes persist even when proofs fail | Eligibility rules |
+| Penalty-free blocking (2) | Split proof validation from `finalizeParticipation` | — |
+| Fabricated-hash coalition (2) | **Not solved by core package** | Rule 4.3.5 validity / fallback |
+| Rollover DoS | Fixed-cap state, no bulk delete | `MAX_COMMITS` |
 
-These raise sybil cost but do not cap N alone. They pair with `MAX_COMMITS`.
-
-**1. Extend `commit()` with stored depth**
-
-```solidity
-commit(bytes32 _obfuscatedHash, uint64 _roundNumber, uint8 _depth)
-```
-
-Store `declaredDepth` in `Commit`. At `reveal()`, require `_depth == declaredDepth` before proximity and floor checks.
-
-**2. Eligibility at commit**
-
-```
-require(height <= MAX_STAKE_HEIGHT)
-require(_depth <= MAX_REPORTED_DEPTH)
-require(_depth > height)
-depthResponsibility = _depth - height
-inProximity(overlay, currentRoundAnchor(), depthResponsibility)
-_depth >= currentFloor()
-```
-
-**3. Depth floor:** governed or bootstrap `currentFloor()`. Floor changes are round-versioned and activate only in a future round; store the applicable value in round/commit state so governance cannot accept a commit under one floor and force its reveal to fail under another. See [MINIMUM_DEPTH_OPTIONS.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/MINIMUM_DEPTH_OPTIONS.md).
-
-**4. Staking:** validate the resulting post-state on every height change, including `_addAmount == 0`: `potentialStake >= MIN_STAKE * 2^newHeight`. Specify whether `committedStake` is recomputed at the current oracle price; do not leave this to implementer interpretation.
-
-**5. Stake state:** ensure selected participants cannot withdraw or mutate stake/overlay/height during their obligation window. Snapshot values for selection, but apply penalties to the same owner/stake identity that created the commit.
-
-**6. Objective validity:** if all-revealing fabricated cohorts are in scope, require a bounded reveal-time sample/validity proof or design a timeout-and-fallback mechanism. This is a required liveness decision for attack 3, not an optional hardening item.
-
-### Attack mitigation matrix
-
-Attacks covered: (1) zero-reveal lock, (2) claim gas grief, (3) truth poisoning / penalty-free blocking, (4) commit-only spam.
-
-`MAX_COMMITS` remains a placeholder until measured. The examples below use K selected participants, not an assumed safe value of 100.
-
-#### 1. Zero reveal
-
-- Bounded admission limits work to K.
-- `finalizeParticipation()` freezes all selected non-revealers and closes the round.
-- This defense depends on someone calling `finalizeParticipation()` before the deadline.
-- The pot carries forward; there is no winner for that round.
-
-#### 2. Commit/reveal gas grief
-
-- Online admission keeps storage and each later scan bounded by K.
-- Fork benchmarks must cover worst-case K external freeze calls and not only happy-path proof verification.
-
-#### 3. Truth poisoning / proof deadlock
-
-- The fabricated tuple can still win the stake-weighted lottery; admission and floors do not prevent that.
-- Staged finalization stops a false truth from freezing honest disagreeing revealers or updating price before proofs pass.
-- **Fix for the penalty rollback bug:** `finalizeParticipation()` persists non-reveal freezes even when later proof validation fails.
-- All-revealing fabricated cohorts still need objective reveal validity or a timeout/fallback (see eligibility rule 6).
-
-#### 4. Commit-only spam with at least one reveal
-
-- Participation finalization persists non-reveal freezes before proof validation, fixing the rollback bug for commit-only sybils.
-- If an honest node was selected and reveals valid truth, settlement can apply disagreement policy, update the oracle, and pay.
-- Admission remains probabilistic: this outcome assumes the honest node was selected.
-
-#### Slot filling (supports attacks 1–4)
-
-- FCFS allows transaction-speed exclusion.
-- Bounded stake-weighted admission makes selection depend on fixed identity and objectively locked stake rather than arrival order.
-- It does not guarantee honest inclusion. A coalition with sufficient total weight can occupy all K positions.
-
-#### Rollover (supports attacks 1–2)
-
-- Fixed-cap/generation-tagged state prevents dynamic-array deletion from becoming the next-round DoS.
+---
 
 ## Rationale
 
-**Bounded admission vs. economic filters alone.** Depth floors, proximity, and stake minimums raise sybil cost but cannot cap per-round work. A hard `MAX_COMMITS` with stake-weighted online selection bounds gas while reducing pure FCFS racing.
+**Why bounded admission, not only economic filters.** Depth floors, proximity, and minimum stake raise cost but cannot cap per-round work. `MAX_COMMITS` with stake-weighted selection bounds gas and reduces FCFS slot racing.
 
-**Staged finalization vs. monolithic `claim()`.** Splitting participation finalization from proof validation fixes the penalty rollback bug: objective non-reveal penalties must persist even when a dishonest tentative winner fails proofs. Subjective disagreement penalties and oracle updates require validated truth.
+**Why staged finalization.** Objective facts (did not reveal) can be finalized before storage proofs. Subjective facts (disagreement, oracle, payout) require validated truth. Fixes **B1** without letting a false tentative truth penalize honest revealers.
 
-**Stake-weighted vs. proximity-ranked admission.** Stake weight aligns admission with existing truth-selection economics; proximity ranking is analyzed in [ADMISSION_COMPARISON.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/ADMISSION_COMPARISON.md). This SWIP recommends stake-weighted admission as the default.
+**Why stake-weighted admission.** Aligns with existing truth-selection economics; proximity ranking is analyzed separately in ADMISSION_COMPARISON.md.
 
-**Current-round-only payout rights.** Because `PostageStamp.withdraw()` transfers the global pot, stale winners must not withdraw after later rounds accrue value. Expiring unpaid rights at rollover is the lighter-weight option; escrow requires PostageStamp changes.
+**Why current-round-only payout rights.** Global `withdraw()` must not let a stale winner drain a pot enlarged by later rounds. Expiring unpaid rights at rollover is lighter than PostageStamp escrow.
 
-**Fabricated-hash coalitions remain out of scope for the core package.** Admission and staged finalization prevent penalty-free blocking and gas grief but do not cryptographically prevent a coalition from revealing a shared fabricated hash. That requires a separate liveness mechanism (reveal-time validity proofs or timeout/fallback).
+**What the core package does not solve.** A coalition that all reveals the same fabricated hash and wins truth still needs cryptographic reveal validity or an audited timeout/fallback — a separate liveness decision.
+
+---
 
 ## Backwards Compatibility
 
-This SWIP introduces breaking changes to the on-chain redistribution interface:
+Breaking changes:
 
-- `commit()` gains a `_depth` parameter and admission may reject commits that would have been accepted under the current contract.
-- Atomic `claim()` is replaced by up to three claim-phase actions with new state fields and deadlines.
-- Round state layout changes from unbounded dynamic arrays to fixed-capacity, generation-tagged structures.
+- `commit()` gains `_depth`; admission may reject previously valid commits.
+- Atomic `claim()` → up to three claim-phase actions with new state and deadlines.
+- Unbounded arrays → fixed-capacity, generation-tagged structures.
 
-Existing Bee clients and indexers must be updated to:
+Bee clients and indexers must track admission/eviction, call staged finalization, and handle expired payout rights. Deployed contracts require upgrade or redeployment.
 
-- Track admission/eviction status during commit.
-- Call the staged finalization API instead of a single `claim()`.
-- Handle rounds that expire payout rights at rollover.
-
-Deployed contracts require upgrade or redeployment; there is no in-place migration path for in-flight rounds under the old layout.
+---
 
 ## Test Cases
 
-Mandatory before setting `MAX_COMMITS` and merging implementation:
+Before setting `MAX_COMMITS`:
 
-1. **Sybil scaling gas tests** on a Gnosis Chain fork: measure `claim()` and each staged step at N ∈ {1, 10, 100, 500, MAX_COMMITS} with commit-only and mixed reveal profiles.
-2. **Penalty persistence:** `finalizeParticipation()` followed by failing `verifyWinner()` must leave non-reveal freezes in place.
-3. **Zero-reveal rounds:** `finalizeParticipation()` must freeze commit-only sybils and close the round without payout.
-4. **Payout retry:** simulated `PostageStamp.withdraw()` failure must not consume payout rights; `settleRound()` must remain callable until success or deadline.
-5. **Admission fairness:** statistical tests that stake-weighted selection approximates proportional inclusion over many rounds.
-6. **Rollover cleanup:** worst-case K participants must not make next-round commit/reveal exceed block gas via storage deletion.
+1. Sybil scaling gas on Gnosis fork: staged steps at N ∈ {1, 10, 100, 500, MAX}.
+2. `finalizeParticipation` + failing `verifyWinner` leaves non-reveal freezes in place.
+3. Empty round: `finalizeParticipation` closes without payout.
+4. `PostageStamp.withdraw()` failure does not consume payout rights.
+5. Stake-weighted admission fairness over many rounds.
+6. Worst-case K participants do not DoS next-round commit via storage cleanup.
 
-Illustrative thresholds in the Specification section are not acceptance criteria until replaced by measured values from these tests.
+Illustrative gas thresholds are not acceptance criteria until measured.
+
+---
 
 ## Implementation
 
-Reference implementation and extended design notes live in the [storage-incentives](https://github.com/ethersphere/storage-incentives) repository:
+Reference: [storage-incentives](https://github.com/ethersphere/storage-incentives) (`fix/minimal_depth_resolve` branch)
 
 - [`Redistribution.sol`](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/src/Redistribution.sol)
 - [`Staking.sol`](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/src/Staking.sol)
-- [Threat model source document](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/SPAM_GRIEFING.md)
-- [Depth floor options](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/MINIMUM_DEPTH_OPTIONS.md)
-- [Admission comparison](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/ADMISSION_COMPARISON.md)
+- [SPAM_GRIEFING.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/SPAM_GRIEFING.md)
+- [MINIMUM_DEPTH_OPTIONS.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/MINIMUM_DEPTH_OPTIONS.md)
 
-**Status:** proposed mitigation architecture. Not yet implemented in production contracts.
+**Status:** proposed architecture; not in production.
 
 ## Roadmap
 
-1. Fork benchmarks on Gnosis Chain to set `MAX_COMMITS` with margin.
-2. Specify exact weighted admission algorithm and `RoundState` layout.
-3. Implement staged finalization in `Redistribution.sol` and update Bee client.
-4. Decide step-1 caller incentives for zero-reveal rounds.
-5. Specify objective reveal validity or timeout/fallback for fabricated-hash coalitions.
-6. Governance parameters for depth floor versioning ([MINIMUM_DEPTH_OPTIONS.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/MINIMUM_DEPTH_OPTIONS.md)).
+1. Gnosis fork benchmarks → `MAX_COMMITS`
+2. Exact weighted admission algorithm and `RoundState` layout
+3. Staged finalization + Bee client update
+4. Empty-round step-1 incentives
+5. Fabricated-hash validity or timeout/fallback
+6. Depth floor governance ([MINIMUM_DEPTH_OPTIONS.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/MINIMUM_DEPTH_OPTIONS.md))
 
 ## Copyright
 

--- a/SWIPs/swip-51.md
+++ b/SWIPs/swip-51.md
@@ -204,41 +204,6 @@ Bee clients and indexers must track admission/eviction, call staged finalization
 
 ---
 
-## Test Cases
-
-Before setting `MAX_COMMITS`:
-
-1. Sybil scaling gas on Gnosis fork: staged steps at N ∈ {1, 10, 100, 500, MAX}.
-2. `finalizeParticipation` + failing `verifyWinner` leaves non-reveal freezes in place.
-3. Empty round: `finalizeParticipation` closes without payout.
-4. `PostageStamp.withdraw()` failure does not consume payout rights.
-5. Stake-weighted admission fairness over many rounds.
-6. Worst-case K participants do not DoS next-round commit via storage cleanup.
-
-Illustrative gas thresholds are not acceptance criteria until measured.
-
----
-
-## Implementation
-
-Reference: [storage-incentives](https://github.com/ethersphere/storage-incentives) (`fix/minimal_depth_resolve` branch)
-
-- [`Redistribution.sol`](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/src/Redistribution.sol)
-- [`Staking.sol`](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/src/Staking.sol)
-- [SPAM_GRIEFING.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/SPAM_GRIEFING.md)
-- [MINIMUM_DEPTH_OPTIONS.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/MINIMUM_DEPTH_OPTIONS.md)
-
-**Status:** proposed architecture; not in production.
-
-## Roadmap
-
-1. Gnosis fork benchmarks → `MAX_COMMITS`
-2. Exact weighted admission algorithm and `RoundState` layout
-3. Staged finalization + Bee client update
-4. Empty-round step-1 incentives
-5. Fabricated-hash validity or timeout/fallback
-6. Depth floor governance ([MINIMUM_DEPTH_OPTIONS.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/MINIMUM_DEPTH_OPTIONS.md))
-
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/SWIPs/swip-51.md
+++ b/SWIPs/swip-51.md
@@ -14,21 +14,30 @@ requires: 21
 
 ## Simple Summary
 
-Sybil stakers can inflate `Redistribution` commit count so honest `claim()` becomes too expensive or fails proofs, blocking round payout without penalty. This SWIP lists those attacks, documents current contract bugs, and proposes bounded admission plus staged claim finalization.
+Sybil stakers can inflate `Redistribution` commit count so honest `claim()` becomes too expensive or fails proofs, blocking round payout without penalty. This SWIP documents the attacks and bugs, specifies **shared** mitigations (bounded admission and related eligibility), and defines **two alternative claim-path options**: decouple `claim()` now, or keep a single `claim()` after [SWIP-49](https://github.com/lat-murmeldjur/SWIPs/blob/6ef788105eaefd7055135c89f2ba14beb59722b2/SWIPs/swip-49.md) and [SWIP-50](https://github.com/lat-murmeldjur/SWIPs/blob/617972b9f4bf009db91e456d0b5fde819057665b/SWIPs/swip-050.md) land.
 
 ## Abstract
 
 `Redistribution` runs commit → reveal → claim to pay storers and update the price oracle ([SWIP-21](./swip-21.md)). `currentCommits` is unbounded; claim work scales O(N). On Gnosis (~17M block gas), ~100 sybils can exceed wallet caps and ~660 can approach the block limit.
 
-Penalties computed in `winnerSelection()` roll back when proof verification fails; failed pot withdrawal still consumes the round. Depth floors raise cost but do not cap N.
+Penalties in `winnerSelection()` roll back when later proof verification fails (**B1**). Failed pot withdrawal can still consume the round (**B2**). Depth floors raise cost but do not cap N (**B3**).
 
-**Proposed fix:** (1) stake-weighted bounded admission, (2) participation finalization that persists non-reveal penalties before proofs, (3) proof-gated disagreement penalties, oracle update, and payout. Fabricated-hash coalitions still need reveal-time validity or a timeout/fallback (out of scope for the core package).
+**This SWIP splits mitigations into:**
+
+1. **Shared package** — implement regardless of claim shape: stake-weighted `MAX_COMMITS`, fixed-cap state, supporting eligibility, and a safe payout/retry rule for **B2**.
+2. **Claim-path choice (pick one):**
+   - **Option A — Decouple `claim()`** (this SWIP): staged `finalizeParticipation` → `verifyWinner` → `settleRound` so objective non-reveal penalties persist before proofs.
+   - **Option B — Keep single `claim()`** after **SWIP-49 + SWIP-50**: proof-before-selection and unfinished-commit carry-over largely remove the need for staging for truth-poison / **B1**.
+
+Fabricated all-revealing coalitions may still need further validity or timeout/fallback beyond either option.
 
 ## Motivation
 
-`claim()` liveness is a protocol requirement: stalled rounds stop rewards and price discovery. No real Bee storage is required to commit or reveal; chunk proofs are checked only at claim.
+`claim()` liveness is a protocol requirement: stalled rounds stop rewards and price discovery. No real Bee storage is required to commit or reveal under the current contract; chunk proofs are checked only at claim.
 
 Production deploys on Gnosis Chain (chainId 100), not Ethereum L1.
+
+Shared work (admission, eligibility, payout safety) should not wait on the claim-path decision. Claim decoupling and STS-1 are **alternatives** for the same failure modes around penalty rollback and fabricated truth — not a stack of both by default.
 
 ---
 
@@ -41,7 +50,7 @@ Production deploys on Gnosis Chain (chainId 100), not Ethereum L1.
 - **Sybil farm:** many staked addresses, one commit per overlay per round (`AlreadyCommitted`), one reveal per commit (`AlreadyRevealed`).
 - **Entry cost per sybil:** `MIN_STAKE * 2^height` (10 BZZ at height 0), two-round stake wait, commit/reveal gas. `manageStake()` resets the wait.
 - **Commit vs reveal:** `commit()` has no proximity check; `reveal()` requires proximity. Cheapest path: `depth == height` (proximity always passes, lowest `stakeDensity`).
-- **`claim()`:** permissionless — any caller with valid proofs pays gas; pot goes to `winner.owner`.
+- **`claim()`:** permissionless — any caller with valid proofs pays gas; pot goes to `winner.owner`. Failed `claim()` does not set `AlreadyClaimed`; anyone may retry until one succeeds. Junk proofs only burn caller gas and are not a standalone DoS.
 
 #### Where N hurts
 
@@ -67,9 +76,7 @@ G_claim(N) ≈ 450k + (N − 1) × 25k
 
 Examples: N = 100 → ~2.9M; N = 500 → ~12.9M; N = 660 → ~17M (block cliff).
 
-Commit-phase attacker cost is O(N²) (uniqueness scans) — partial deterrent, not protection for the single `claim()` tx.
-
-~100 sybils ≈ 1,000 BZZ locked at height 0; ~660 ≈ 6,600 BZZ. If every claim is blocked, no freeze applies (rollback bug). Figures are engineering estimates; benchmark on a Gnosis fork before setting `MAX_COMMITS`.
+Commit-phase attacker cost is O(N²) (uniqueness scans) — partial deterrent, not protection for the single `claim()` tx. ~100 sybils ≈ 1,000 BZZ locked at height 0; ~660 ≈ 6,600 BZZ. If every claim is blocked, no freeze applies (rollback bug). Figures are engineering estimates; benchmark on a Gnosis fork before setting `MAX_COMMITS`.
 
 ---
 
@@ -95,7 +102,7 @@ All scenarios assume **honest nodes are playing** and at least one reveal exists
 
 | ID | Bug | Symptom |
 |----|-----|---------|
-| **B1** | Penalties inside same tx as proofs | Proof failure reverts all `freezeDeposit()` and `currentClaimRound` — blocking nodes stay unpenalized |
+| **B1** | Penalties inside same tx as post-selection proofs | Proof / OOG failure reverts all `freezeDeposit()` and `currentClaimRound` — blocking nodes stay unpenalized |
 | **B2** | Payout failure treated as success | `WithdrawFailed` emitted but round marked claimed; winner cannot retry |
 | **B3** | Unbounded `currentCommits` | Claim and rollover work scale with attacker-chosen N |
 
@@ -112,38 +119,38 @@ All scenarios assume **honest nodes are playing** and at least one reveal exists
 
 ---
 
-### 4. Proposed mitigations
+### 4. Mitigation architecture
 
-Three layers — admission bounds work; staging fixes **B1** and **B2**; eligibility raises sybil cost.
+Mitigations fall into a **shared package** (always) and a **claim-path choice** (exactly one of Option A or Option B).
 
+```text
+                    ┌─────────────────────────────────────┐
+                    │  SHARED (§4.1)                        │
+                    │  MAX_COMMITS + fixed-cap state        │
+                    │  eligibility + B2 payout safety       │
+                    └──────────────┬──────────────────────┘
+                                   │
+              ┌────────────────────┴────────────────────┐
+              ▼                                         ▼
+   Option A (§4.2)                             Option B (§4.3)
+   Decouple claim now                          Keep single claim
+   (this SWIP)                                 after SWIP-49 + SWIP-50
 ```
-bounded online admission (MAX_COMMITS)
-        +
-finalizeParticipation — persist non-reveal penalties
-        +
-verifyWinner → settleRound — proofs before subjective penalties, oracle, payout
-```
 
-#### 4.1 Staged claim finalization
+| Concern | Shared | Option A (decouple) | Option B (49+50, single claim) |
+|---------|--------|---------------------|--------------------------------|
+| Gas grief / **B3** / rollover | **Required** | — | — |
+| Truth poison / **B1** | — | Staged penalties before proofs | Proof-before-selection + unfinished-commit carry-over |
+| **B2** payout retry | **Required** (either path) | Via `settleRound` | Via claim ordering / pending payout design in 49–50 |
+| Do both A and B? | — | **No** — pick one claim path | **No** — pick one claim path |
 
-Replace atomic `claim()` with ordered steps (same claim window; payout rights expire at rollover):
+---
 
-| Step | Function | Persists on revert | Purpose |
-|------|----------|-------------------|---------|
-| 1 | `finalizeParticipation(round)` | **Yes** — non-reveal freezes | Store tentative truth/winner; cap loop at K commits |
-| 2 | `verifyWinner(round, proofs…)` | No | Validate chunk/stamp/SOC proofs; mark `truthValidated` |
-| 3 | `settleRound(round)` | Retryable | Disagreement penalties, oracle, pot withdraw — only after **B2**-safe success |
+### 4.1 Shared package (implement either way)
 
-**Rules:**
+These items do **not** depend on decoupling `claim()`. They can ship before the claim-path decision is final.
 
-- Step 1 must **not** freeze disagreeing revealers or adjust the oracle (tentative truth may be fabricated).
-- Invalid `verifyWinner` calldata must not slash the winner (anyone can submit bad proofs).
-- `PostageStamp.withdraw()` pulls the global pot — use current-round-only payout rights or round escrow (PostageStamp change).
-- Snapshot reveal anchor, proof seed, truth, winner in `RoundState`; no bulk-delete unbounded arrays — use fixed-cap / generation-tagged storage.
-
-**Open design:** step-1 caller incentive on empty rounds; optional `verifyAndSettle(proofs)` wrapper for steps 2–3.
-
-#### 4.2 Bounded admission (`MAX_COMMITS`)
+#### 4.1.1 Bounded admission (`MAX_COMMITS`)
 
 - Hard cap on selected commits bounds all O(N) loops and freeze calls.
 - **Not FCFS** — sybils would race to fill slots. Use stake-weighted online selection:
@@ -156,53 +163,172 @@ priority = auditedWeightedPriority(entropy, weight)
 
 Keep best K by priority; O(log K) eviction per commit. Emit admission/eviction events. Set K only after fork benchmarks at N = MAX with margin.
 
-See [ADMISSION_COMPARISON.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/ADMISSION_COMPARISON.md) for stake-weighted vs proximity-ranked admission.
+See [ADMISSION_COMPARISON.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/ADMISSION_COMPARISON.md).
 
-#### 4.3 Eligibility rules (supporting — do not cap N alone)
+Under Option B, also bound any **carry-over** unfinished-commit list (SWIP-50 `pendingCompletion`) so a later successful claim cannot OOG on accumulated unfinished sybils.
+
+#### 4.1.2 Fixed-capacity round state
+
+No bulk-delete of attacker-sized dynamic arrays. Use fixed-cap / generation-tagged storage (or equivalent cursor-bounded cleanup) so rollover cannot become the next-round DoS.
+
+#### 4.1.3 Eligibility rules (supporting — do not cap N alone)
 
 1. `commit(obfuscatedHash, round, depth)` — store `declaredDepth`; reveal must match.
 2. Commit requires proximity, `depth > height`, depth floor — see [MINIMUM_DEPTH_OPTIONS.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/MINIMUM_DEPTH_OPTIONS.md).
 3. Validate `potentialStake >= MIN_STAKE * 2^newHeight` on every height change.
 4. Lock stake/overlay/height for selected participants until obligation ends.
-5. **Separate decision (attack 2):** reveal-time validity sample or timeout/fallback for fabricated-hash coalitions.
 
-#### 4.4 Attack → mitigation map
+#### 4.1.4 Payout safety (**B2**)
 
-| Attack | Primary fix | Also helps |
-|--------|-------------|------------|
-| Gas grief (1, 3) | `MAX_COMMITS` + staged loops | O(N²) commit cost (existing) |
-| Truth poison (2) | Staging: non-reveal freezes persist even when proofs fail | Eligibility rules |
-| Penalty-free blocking (2) | Split proof validation from `finalizeParticipation` | — |
-| Fabricated-hash coalition (2) | **Not solved by core package** | Rule 4.3.5 validity / fallback |
-| Rollover DoS | Fixed-cap state, no bulk delete | `MAX_COMMITS` |
+Settlement must not consume the round’s payout right on a failed pot transfer. Either:
+
+- revert settlement / keep an explicit retryable payout state until success or deadline; or
+- credit round-scoped pending balances and expose a separate withdraw (as sketched in SWIP-50).
+
+Because `PostageStamp.withdraw()` pulls the **global** pot, unpaid rights must be **current-round-only** or use round escrow. Storing a stale finalized winner while calling global `withdraw()` later is unsafe.
+
+---
+
+### 4.2 Option A — Decouple `claim()` (this SWIP)
+
+**When to choose:** ship a fix for **B1** / truth-poison **without** waiting for SWIP-49/50; keep today’s reveal → select → prove ordering.
+
+Replace atomic `claim()` with ordered steps inside the claim window (payout rights expire at rollover):
+
+| Step | Function | Persists on revert | Purpose |
+|------|----------|-------------------|---------|
+| 1 | `finalizeParticipation(round)` | **Yes** — non-reveal freezes | Store tentative truth/winner; loop capped at K |
+| 2 | `verifyWinner(round, proofs…)` | No | Validate chunk/stamp/SOC proofs; mark `truthValidated` |
+| 3 | `settleRound(round)` | Retryable | Disagreement penalties, oracle, pot — only after validated truth |
+
+**Rules:**
+
+- Step 1 must **not** freeze disagreeing revealers or adjust the oracle (tentative truth may be fabricated).
+- Invalid `verifyWinner` calldata must not slash the winner (anyone can submit junk proofs).
+- Snapshot reveal anchor, proof seed, truth, winner in `RoundState`.
+- Optional: `verifyAndSettle(proofs)` convenience wrapper for steps 2–3.
+
+**Open design:** step-1 caller incentive on empty rounds.
+
+**Does not require:** SWIP-49 or SWIP-50.
+
+**If Option A ships first:** Option B’s single-claim design should not reintroduce freeze-before-proof for the legacy selection order. Prefer one claim path in production.
+
+---
+
+### 4.3 Option B — Keep single `claim()` after SWIP-49 + SWIP-50
+
+**When to choose:** accept waiting for the STS redesign; avoid multi-step claim UX/client changes for **B1**/truth-poison.
+
+| Draft | Role for this SWIP |
+|-------|--------------------|
+| [SWIP-49](https://github.com/lat-murmeldjur/SWIPs/blob/6ef788105eaefd7055135c89f2ba14beb59722b2/SWIPs/swip-49.md) | Fixed postage scope for a target round; claim verifies postage against sampling-start state; price update after proofs |
+| [SWIP-50](https://github.com/lat-murmeldjur/SWIPs/blob/617972b9f4bf009db91e456d0b5fde819057665b/SWIPs/swip-050.md) | STS-1: stamp + chunk-binding proofs **before** truth-selection weight; unfinished stage-one commits carried to the next successful claim |
+
+**Why this can replace decoupling for B1 / attack 2:**
+
+- Fabricated Schelling values get **no selection weight** until stamp witnesses and STS binding proofs pass → classic poison → claim-proof-fail loop is largely removed.
+- Unfinished commits remain pending and can be frozen by a **later** successful claim if this round never claims → non-reveal pressure does not depend on same-round claim success alone.
+
+**Still required from §4.1:** `MAX_COMMITS` (and a bound on unfinished carry-over), fixed-cap state, eligibility as applicable, **B2**-safe payout.
+
+**Does not by itself solve:** unbounded N, rollover bulk-delete, or one-copy-many-overlays (SWIP-50 non-goal).
+
+**If Option B is chosen:** do **not** also implement Option A’s three-step claim as the default path. Shared §4.1 items still apply.
+
+---
+
+### 4.4 Attack → mitigation map
+
+| Attack / bug | Shared (§4.1) | Option A | Option B |
+|--------------|---------------|----------|----------|
+| Gas grief (1, 3) / **B3** | `MAX_COMMITS` + fixed-cap state | Same | Same (+ bound `pendingCompletion`) |
+| Truth poison (2) / **B1** | — | Staging: non-reveal freezes persist when proofs fail | Proof-before-selection + unfinished carry-over |
+| Penalty-free blocking while claim fails | — | Split finalize vs prove | Selection only over proof-validated entries |
+| **B2** | Payout retry / pending withdraw | Via `settleRound` | Via 49/50 claim + pending payout design |
+| Rollover DoS | Fixed-cap state | Same | Same |
+| Fabricated-hash coalition (remaining) | Out of core package | May still need validity / timeout | STS raises bar; physical-replica issues remain out of scope |
 
 ---
 
 ## Rationale
 
-**Why bounded admission, not only economic filters.** Depth floors, proximity, and minimum stake raise cost but cannot cap per-round work. `MAX_COMMITS` with stake-weighted selection bounds gas and reduces FCFS slot racing.
+**Shared admission first.** Depth floors and stake raise cost but cannot cap per-round work. `MAX_COMMITS` is required under **both** claim paths.
 
-**Why staged finalization.** Objective facts (did not reveal) can be finalized before storage proofs. Subjective facts (disagreement, oracle, payout) require validated truth. Fixes **B1** without letting a false tentative truth penalize honest revealers.
+**Two claim paths, one choice.** Decoupling (Option A) fixes **B1** under the *current* select-then-prove order. SWIP-49/50 (Option B) change the order to prove-then-select, which removes most of the reason to stage `claim()` for poison/B1. Implementing both as concurrent defaults would duplicate complexity without clear gain.
 
-**Why stake-weighted admission.** Aligns with existing truth-selection economics; proximity ranking is analyzed separately in ADMISSION_COMPARISON.md.
+**Why not Option B alone without §4.1.** STS does not bound N; gas grief and rollover DoS remain.
 
-**Why current-round-only payout rights.** Global `withdraw()` must not let a stale winner drain a pot enlarged by later rounds. Expiring unpaid rights at rollover is lighter than PostageStamp escrow.
+**Why not Option A alone forever if 49/50 ship.** Once proof-before-selection is live, staged claim is largely redundant for attack 2; keep one claim model to avoid dual client paths.
 
-**What the core package does not solve.** A coalition that all reveals the same fabricated hash and wins truth still needs cryptographic reveal validity or an audited timeout/fallback — a separate liveness decision.
+**Stake-weighted admission.** Aligns with existing truth-selection economics; proximity ranking is analyzed in ADMISSION_COMPARISON.md.
+
+**What neither option fully solves.** An all-revealing coalition with sufficient real-looking evidence may still need a separate liveness mechanism (validity sample or timeout/fallback).
+
+---
+
+## Decision and roadmap
+
+1. Implement **§4.1 shared package** (admission, fixed-cap state, eligibility, **B2** payout safety).
+2. Choose **exactly one**:
+   - **Option A** — specify and implement staged claim (§4.2); or
+   - **Option B** — wait for SWIP-49 + SWIP-50, keep single `claim()`, ensure unfinished-list gas is capped (§4.3).
+3. Re-evaluate fabricated-hash / physical-storage residual risks after the chosen path ships.
+4. Fork-benchmark `MAX_COMMITS` (and Option B carry-over bound) on Gnosis before locking parameters.
 
 ---
 
 ## Backwards Compatibility
 
-Breaking changes:
+**Shared (§4.1):**
 
-- `commit()` gains `_depth`; admission may reject previously valid commits.
+- `commit()` may gain `_depth` and admission may reject previously valid commits.
+- Round state moves from unbounded arrays to fixed-capacity / generation-tagged structures.
+
+**Option A only:**
+
 - Atomic `claim()` → up to three claim-phase actions with new state and deadlines.
-- Unbounded arrays → fixed-capacity, generation-tagged structures.
+- Bee clients must call staged finalization and handle expired payout rights.
 
-Bee clients and indexers must track admission/eviction, call staged finalization, and handle expired payout rights. Deployed contracts require upgrade or redeployment.
+**Option B only:**
+
+- Breaking changes are those of SWIP-49 and SWIP-50 (round phases, proof submission, postage reads, payout distribution).
+- Bee clients follow the STS sequence; no SWIP-51 three-step claim API.
+
+Deployed contracts require upgrade or redeployment in either case.
 
 ---
+
+## Test Cases
+
+**Shared:**
+
+1. Sybil scaling gas on Gnosis fork at N ∈ {1, 10, 100, 500, MAX_COMMITS}.
+2. Failed pot transfer does not consume payout rights.
+3. Worst-case K participants do not DoS next-round commit via storage cleanup.
+4. Stake-weighted admission fairness over many rounds.
+
+**Option A:**
+
+5. `finalizeParticipation` + failing `verifyWinner` leaves non-reveal freezes in place.
+6. Empty round: `finalizeParticipation` closes without payout.
+
+**Option B:**
+
+7. Entry without STS proof has zero truth-selection weight.
+8. Unfinished stage-one commits freeze on a later successful claim; carry-over size stays within gas budget at MAX.
+
+Illustrative gas thresholds are not acceptance criteria until measured.
+
+---
+
+## Implementation
+
+- Current contracts: [storage-incentives](https://github.com/ethersphere/storage-incentives) (`Redistribution.sol`, `Staking.sol`)
+- Threat model notes: [SPAM_GRIEFING.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/SPAM_GRIEFING.md) (align with this SWIP when updating)
+- Draft alternatives: [SWIP-49](https://github.com/lat-murmeldjur/SWIPs/blob/6ef788105eaefd7055135c89f2ba14beb59722b2/SWIPs/swip-49.md), [SWIP-50](https://github.com/lat-murmeldjur/SWIPs/blob/617972b9f4bf009db91e456d0b5fde819057665b/SWIPs/swip-050.md)
+
+**Status:** draft architecture. Shared package and claim-path choice are not yet in production.
 
 ## Copyright
 

--- a/SWIPs/swip-51.md
+++ b/SWIPs/swip-51.md
@@ -65,11 +65,11 @@ G_claim(N) ≈ 450k + (N − 1) × 25k
 | ~3M     | Wallet / RPC cap     | ~100              |
 | ~17M    | Gnosis block limit   | ~660              |
 
-**Sepolia validation (round 74469, honest nodes active):** 100 sybil commits + ~7 honest → honest `claim()` used **2,842,847** gas (estimate ~2.9M). Claim succeeded; sybils frozen. Liveness break at N≈100 raises cost but did not block claim; higher N or truth poisoning required.
+Examples: N = 100 → ~2.9M; N = 500 → ~12.9M; N = 660 → ~17M (block cliff).
 
 Commit-phase attacker cost is O(N²) (uniqueness scans) — partial deterrent, not protection for the single `claim()` tx.
 
-~100 sybils ≈ 1,000 BZZ locked at height 0; ~660 ≈ 6,600 BZZ. If every claim is blocked, no freeze applies (rollback bug). Re-measure on a Gnosis fork before setting `MAX_COMMITS`.
+~100 sybils ≈ 1,000 BZZ locked at height 0; ~660 ≈ 6,600 BZZ. If every claim is blocked, no freeze applies (rollback bug). Figures are engineering estimates; benchmark on a Gnosis fork before setting `MAX_COMMITS`.
 
 ---
 

--- a/SWIPs/swip-51.md
+++ b/SWIPs/swip-51.md
@@ -1,7 +1,7 @@
 ---
-SWIP: 24
+SWIP: 51
 title: Redistribution spam and griefing mitigation
-author: Marko Cardinal (@0xCardiE)
+author: Mark Bliss (@n00b21337)
 discussions-to: https://discord.gg/Q6BvSkCv (Swarm Discord '#swips')
 status: Draft
 type: Standards Track


### PR DESCRIPTION
## Summary

- Adds [SWIP-51](./SWIPs/swip-51.md) documenting the sybil spam and griefing threat model against `Redistribution.sol`
- Specifies gas thresholds on Gnosis Chain, current contract penalty bugs, and the proposed mitigation package (bounded online admission, staged participation finalization, proof-gated payout)
- Adapted from [storage-incentives/docs/SPAM_GRIEFING.md](https://github.com/ethersphere/storage-incentives/blob/fix/minimal_depth_resolve/docs/SPAM_GRIEFING.md)